### PR TITLE
Refatorando a função `cnpj.format` e melhorando seus testes

### DIFF
--- a/brutils/cnpj.py
+++ b/brutils/cnpj.py
@@ -93,7 +93,7 @@ def is_valid(cnpj):  # type: (str) -> bool
     Using this method name to match with the js library  api.
     Using the same method to ensure backwards compatibility.
     """
-    return validate(cnpj)
+    return isinstance(cnpj, str) and validate(cnpj)
 
 
 def generate(branch=1):  # type: (int) -> str

--- a/brutils/cnpj.py
+++ b/brutils/cnpj.py
@@ -38,7 +38,13 @@ def format_cnpj(cnpj):  # type: (str) -> str
     Will format an adequately formatted numbers-only CNPJ string,
     adding in standard formatting visual aid symbols for display.
     """
-    return display(cnpj)
+
+    if not is_valid(cnpj):
+        return None
+
+    return "{}.{}.{}/{}-{}".format(
+        cnpj[:2], cnpj[2:5], cnpj[5:8], cnpj[8:12], cnpj[12:14]
+    )
 
 
 # CALCULATORS

--- a/brutils/cpf.py
+++ b/brutils/cpf.py
@@ -45,7 +45,7 @@ def format_cpf(cpf):  # type: (str) -> str
     if not is_valid(cpf):
         return None
 
-    return "{}.{}.{}-{}".format(cpf[:3], cpf[3:6], cpf[6:9], cpf[9:])
+    return "{}.{}.{}-{}".format(cpf[:3], cpf[3:6], cpf[6:9], cpf[9:11])
 
 
 # OPERATIONS

--- a/tests/test_cnpj.py
+++ b/tests/test_cnpj.py
@@ -82,8 +82,7 @@ class CNPJ(TestCase):
 
         # When CNPJ is valid
         assert is_valid("34665388000161")
-        assert not is_valid("52599927000100")
-        assert not is_valid("00000000000")
+        assert is_valid("01838723000127")
 
     def test_generate(self):
         for i in range(1000):

--- a/tests/test_cnpj.py
+++ b/tests/test_cnpj.py
@@ -45,10 +45,18 @@ class CNPJ(TestCase):
         assert display("0000000000000") is None
 
     def test_format_cnpj(self):
-        assert format_cnpj("00000000000109") == "00.000.000/0001-09"
-        assert format_cnpj("00000000000000") is None
-        assert format_cnpj("0000000000000a") is None
-        assert format_cnpj("0000000000000") is None
+        with patch("brutils.cnpj.is_valid", return_value=True) as mock_is_valid:
+            # When cnpj is_valid, returns formatted cnpj
+            assert format_cnpj("01838723000127") == "01.838.723/0001-27"
+
+        # Checks if function is_valid_cnpj is called
+        mock_is_valid.assert_called_once_with("01838723000127")
+
+        with patch(
+            "brutils.cnpj.is_valid", return_value=False
+        ) as mock_is_valid:
+            # When cnpj isn't valid, returns None
+            assert format_cnpj("01838723000127") is None
 
     def test_validate(self):
         assert validate("34665388000161")

--- a/tests/test_cnpj.py
+++ b/tests/test_cnpj.py
@@ -50,6 +50,46 @@ class CNPJ(TestCase):
         assert format_cnpj("0000000000000a") is None
         assert format_cnpj("0000000000000") is None
 
+    def test_validate(self):
+        assert validate("34665388000161")
+        assert not validate("52599927000100")
+        assert not validate("00000000000")
+
+    def test_is_valid(self):
+        # When CNPJ is not string, returns False
+        assert not is_valid(1)
+
+        # When CNPJ's len is different of 14, returns False
+        assert not is_valid("1")
+
+        # When CNPJ does not contain only digits, returns False
+        assert not is_valid("1112223334445-")
+
+        # When CNPJ has only the same digit, returns false
+        assert not is_valid("11111111111111")
+
+        # When rest_1 is lt 2 and the 13th digit is not 0, returns False
+        assert not is_valid("1111111111315")
+
+        # When rest_1 is gte 2 and the 13th digit is not (11 - rest), returns False
+        assert not is_valid("1111111111115")
+
+        # When rest_2 is lt 2 and the 14th digit is not 0, returns False
+        assert not is_valid("11111111121205")
+
+        # When rest_2 is gte 2 and the 14th digit is not (11 - rest), returns False
+        assert not is_valid("11111111113105")
+
+        # When CNPJ is valid
+        assert is_valid("34665388000161")
+        assert not is_valid("52599927000100")
+        assert not is_valid("00000000000")
+
+    def test_generate(self):
+        for i in range(1000):
+            assert validate(generate())
+            assert display(generate()) is not None
+
     def test_hashdigit(self):
         assert hashdigit("00000000000000", 13) == 0
         assert hashdigit("00000000000000", 14) == 0
@@ -59,21 +99,6 @@ class CNPJ(TestCase):
     def test_checksum(self):
         assert checksum("00000000000000") == "00"
         assert checksum("52513127000299") == "99"
-
-    def test_validate(self):
-        assert validate("34665388000161")
-        assert not validate("52599927000100")
-        assert not validate("00000000000")
-
-    def test_is_valid(self):
-        assert is_valid("34665388000161")
-        assert not is_valid("52599927000100")
-        assert not is_valid("00000000000")
-
-    def test_generate(self):
-        for i in range(1000):
-            assert validate(generate())
-            assert display(generate()) is not None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Alterações:
* Garante que a função `format` chama o método `is_valid` para validação do CNPJ e não utiliza o método display;
* Testes ajustados para a nova função (CNPJ);
* Alteração do código do `cpf.format` para definir o tamanho máximo do input

closes #115 