### PR TITLE
Refatoracao cnpj

### DIFF
--- a/brutils/cnpj.py
+++ b/brutils/cnpj.py
@@ -47,33 +47,6 @@ def format_cnpj(cnpj):  # type: (str) -> str
     )
 
 
-# CALCULATORS
-#############
-
-
-def hashdigit(cnpj, position):  # type: (str, int) -> int
-    """
-    Will compute the given `position` checksum digit for the `cnpj`
-    input. The input needs to contain all elements previous to
-    `position` else computation will yield the wrong result.
-    """
-    weightgen = chain(range(position - 8, 1, -1), range(9, 1, -1))
-    val = (
-        sum(int(digit) * weight for digit, weight in zip(cnpj, weightgen)) % 11
-    )
-    return 0 if val < 2 else 11 - val
-
-
-def checksum(basenum):  # type: (str) -> str
-    """
-    Will compute the checksum digits for a given CNPJ base number.
-    `basenum` needs to be a digit-string of adequate length.
-    """
-    verifying_digits = str(hashdigit(basenum, 13))
-    verifying_digits += str(hashdigit(basenum + verifying_digits, 14))
-    return verifying_digits
-
-
 # OPERATIONS
 ############
 
@@ -87,7 +60,7 @@ def validate(cnpj):  # type: (str) -> bool
     if not cnpj.isdigit() or len(cnpj) != 14 or len(set(cnpj)) == 1:
         return False
     return all(
-        hashdigit(cnpj, i + 13) == int(v) for i, v in enumerate(cnpj[12:])
+        _hashdigit(cnpj, i + 13) == int(v) for i, v in enumerate(cnpj[12:])
     )
 
 
@@ -111,6 +84,28 @@ def generate(branch=1):  # type: (int) -> str
     branch += int(branch == 0)
     branch = str(branch).zfill(4)
     base = str(randint(0, 99999999)).zfill(8) + branch
-    while len(set(base)) == 1:
-        base = str(randint(0, 99999999)).zfill(8) + branch
-    return base + checksum(base)
+
+    return base + _checksum(base)
+
+
+def _hashdigit(cnpj, position):  # type: (str, int) -> int
+    """
+    Will compute the given `position` checksum digit for the `cnpj`
+    input. The input needs to contain all elements previous to
+    `position` else computation will yield the wrong result.
+    """
+    weightgen = chain(range(position - 8, 1, -1), range(9, 1, -1))
+    val = (
+        sum(int(digit) * weight for digit, weight in zip(cnpj, weightgen)) % 11
+    )
+    return 0 if val < 2 else 11 - val
+
+
+def _checksum(basenum):  # type: (str) -> str
+    """
+    Will compute the checksum digits for a given CNPJ base number.
+    `basenum` needs to be a digit-string of adequate length.
+    """
+    verifying_digits = str(_hashdigit(basenum, 13))
+    verifying_digits += str(_hashdigit(basenum + verifying_digits, 14))
+    return verifying_digits

--- a/tests/test_cnpj.py
+++ b/tests/test_cnpj.py
@@ -12,13 +12,13 @@ path.insert(
 from brutils.cnpj import (
     sieve,
     display,
-    hashdigit,
-    checksum,
     validate,
     generate,
     is_valid,
     format_cnpj,
     remove_symbols,
+    _hashdigit,
+    _checksum,
 )
 from unittest import TestCase, main
 
@@ -93,19 +93,19 @@ class CNPJ(TestCase):
         assert is_valid("01838723000127")
 
     def test_generate(self):
-        for i in range(1000):
+        for _ in range(10_000):
             assert validate(generate())
             assert display(generate()) is not None
 
-    def test_hashdigit(self):
-        assert hashdigit("00000000000000", 13) == 0
-        assert hashdigit("00000000000000", 14) == 0
-        assert hashdigit("52513127000292", 13) == 9
-        assert hashdigit("52513127000292", 14) == 9
+    def test__hashdigit(self):
+        assert _hashdigit("00000000000000", 13) == 0
+        assert _hashdigit("00000000000000", 14) == 0
+        assert _hashdigit("52513127000292", 13) == 9
+        assert _hashdigit("52513127000292", 14) == 9
 
-    def test_checksum(self):
-        assert checksum("00000000000000") == "00"
-        assert checksum("52513127000299") == "99"
+    def test__checksum(self):
+        assert _checksum("00000000000000") == "00"
+        assert _checksum("52513127000299") == "99"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- `hashdigit` convertido para privado
- `checksum` convertido para privado
- test_generate para cnpj testando criação de 10k cnpj ao invés de 1k

Closes #117 