### PR TITLE
Refactor: Alterando os métodos de `assert` python para unittest

### DIFF
--- a/brutils/cnpj.py
+++ b/brutils/cnpj.py
@@ -93,7 +93,7 @@ def is_valid(cnpj):  # type: (str) -> bool
     Using this method name to match with the js library  api.
     Using the same method to ensure backwards compatibility.
     """
-    return validate(cnpj)
+    return isinstance(cnpj, str) and validate(cnpj)
 
 
 def generate(branch=1):  # type: (int) -> str

--- a/tests/test_cep.py
+++ b/tests/test_cep.py
@@ -20,42 +20,42 @@ from unittest import TestCase, main
 
 class CEP(TestCase):
     def test_remove_symbols(self):
-        assert remove_symbols("00000000") == "00000000"
-        assert remove_symbols("01310-200") == "01310200"
-        assert remove_symbols("01..310.-200.-") == "01310200"
-        assert remove_symbols("abc01310200*!*&#") == "abc01310200*!*&#"
-        assert (
-            remove_symbols("ab.c1.--.3-102.-0-.0-.*.-!*&#") == "abc1310200*!*&#"
+        self.assertEqual(remove_symbols("00000000"), "00000000")
+        self.assertEqual(remove_symbols("01310-200"), "01310200")
+        self.assertEqual(remove_symbols("01..310.-200.-"), "01310200")
+        self.assertEqual(remove_symbols("abc01310200*!*&#"), "abc01310200*!*&#")
+        self.assertEqual(
+            remove_symbols("ab.c1.--.3-102.-0-.0-.*.-!*&#"), "abc1310200*!*&#"
         )
-        assert remove_symbols("...---...") == ""
+        self.assertEqual(remove_symbols("...---..."), "")
 
     def test_format_cep(self):
         with patch("brutils.cep.is_valid", return_value=True) as mock_is_valid:
             # When cep is_valid, returns formatted cep
-            assert format_cep("01310200") == "01310-200"
+            self.assertEqual(format_cep("01310200"), "01310-200")
 
         # Checks if function is_valid_cnpj is called
         mock_is_valid.assert_called_once_with("01310200")
 
         with patch("brutils.cep.is_valid", return_value=False) as mock_is_valid:
             # When cep isn't valid, returns None
-            assert format_cep("013102009") is None
+            self.assertIsNone(format_cep("013102009"))
 
     def test_is_valid(self):
         # When CEP is not string, returns False
-        assert not is_valid(1)
+        self.assertFalse(is_valid(1))
 
         # When CEP's len is different of 8, returns False
-        assert not is_valid("1")
+        self.assertFalse(is_valid("1"))
 
         # When CEP does not contain only digits, returns False
-        assert not is_valid("1234567-")
+        self.assertFalse(is_valid("1234567-"))
 
         # When CEP is valid
-        assert is_valid("99999999")
-        assert is_valid("88390000")
+        self.assertTrue(is_valid("99999999"))
+        self.assertTrue(is_valid("88390000"))
 
     def test_generate(self):
         for _ in range(10_000):
-            assert is_valid(generate())
+            self.assertTrue(is_valid(generate()))
         # assert format(generate()) is not None

--- a/tests/test_cnpj.py
+++ b/tests/test_cnpj.py
@@ -25,12 +25,14 @@ from unittest import TestCase, main
 
 class CNPJ(TestCase):
     def test_sieve(self):
-        assert sieve("00000000000") == "00000000000"
-        assert sieve("12.345.678/0001-90") == "12345678000190"
-        assert sieve("134..2435/.-1892.-") == "13424351892"
-        assert sieve("abc1230916*!*&#") == "abc1230916*!*&#"
-        assert sieve("ab.c1.--.2-3/09.-1-./6/-.*.-!*&#") == "abc1230916*!*&#"
-        assert sieve("/...---.../") == ""
+        self.assertEqual(sieve("00000000000"), "00000000000")
+        self.assertEqual(sieve("12.345.678/0001-90"), "12345678000190")
+        self.assertEqual(sieve("134..2435/.-1892.-"), "13424351892")
+        self.assertEqual(sieve("abc1230916*!*&#"), "abc1230916*!*&#")
+        self.assertEqual(
+            sieve("ab.c1.--.2-3/09.-1-./6/-.*.-!*&#"), "abc1230916*!*&#"
+        )
+        self.assertEqual(sieve("/...---.../"), "")
 
     def test_remove_symbols(self):
         with patch("brutils.cnpj.sieve") as mock_sieve:
@@ -39,15 +41,17 @@ class CNPJ(TestCase):
             mock_sieve.assert_called()
 
     def test_display(self):
-        assert display("00000000000109") == "00.000.000/0001-09"
-        assert display("00000000000000") is None
-        assert display("0000000000000a") is None
-        assert display("0000000000000") is None
+        self.assertEqual(display("00000000000109"), "00.000.000/0001-09")
+        self.assertIsNone(display("00000000000000"))
+        self.assertIsNone(display("0000000000000"))
+        self.assertIsNone(display("0000000000000a"))
 
     def test_format_cnpj(self):
         with patch("brutils.cnpj.is_valid", return_value=True) as mock_is_valid:
             # When cnpj is_valid, returns formatted cnpj
-            assert format_cnpj("01838723000127") == "01.838.723/0001-27"
+            self.assertEqual(
+                format_cnpj("01838723000127"), "01.838.723/0001-27"
+            )
 
         # Checks if function is_valid_cnpj is called
         mock_is_valid.assert_called_once_with("01838723000127")
@@ -56,56 +60,56 @@ class CNPJ(TestCase):
             "brutils.cnpj.is_valid", return_value=False
         ) as mock_is_valid:
             # When cnpj isn't valid, returns None
-            assert format_cnpj("01838723000127") is None
+            self.assertIsNone(format_cnpj("01838723000127"))
 
     def test_validate(self):
-        assert validate("34665388000161")
-        assert not validate("52599927000100")
-        assert not validate("00000000000")
+        self.assertTrue(validate("34665388000161"))
+        self.assertFalse(validate("52599927000100"))
+        self.assertFalse(validate("00000000000"))
 
     def test_is_valid(self):
         # When CNPJ is not string, returns False
-        assert not is_valid(1)
+        self.assertFalse(is_valid(1))
 
         # When CNPJ's len is different of 14, returns False
-        assert not is_valid("1")
+        self.assertFalse(is_valid("1"))
 
         # When CNPJ does not contain only digits, returns False
-        assert not is_valid("1112223334445-")
+        self.assertFalse(is_valid("1112223334445-"))
 
         # When CNPJ has only the same digit, returns false
-        assert not is_valid("11111111111111")
+        self.assertFalse(is_valid("11111111111111"))
 
         # When rest_1 is lt 2 and the 13th digit is not 0, returns False
-        assert not is_valid("1111111111315")
+        self.assertFalse(is_valid("1111111111315"))
 
         # When rest_1 is gte 2 and the 13th digit is not (11 - rest), returns False
-        assert not is_valid("1111111111115")
+        self.assertFalse(is_valid("1111111111115"))
 
         # When rest_2 is lt 2 and the 14th digit is not 0, returns False
-        assert not is_valid("11111111121205")
+        self.assertFalse(is_valid("11111111121205"))
 
         # When rest_2 is gte 2 and the 14th digit is not (11 - rest), returns False
-        assert not is_valid("11111111113105")
+        self.assertFalse(is_valid("11111111113105"))
 
         # When CNPJ is valid
-        assert is_valid("34665388000161")
-        assert is_valid("01838723000127")
+        self.assertTrue(is_valid("34665388000161"))
+        self.assertTrue(is_valid("01838723000127"))
 
     def test_generate(self):
         for _ in range(10_000):
-            assert validate(generate())
-            assert display(generate()) is not None
+            self.assertTrue(validate(generate()))
+            self.assertIsNotNone(display(generate()))
 
     def test__hashdigit(self):
-        assert _hashdigit("00000000000000", 13) == 0
-        assert _hashdigit("00000000000000", 14) == 0
-        assert _hashdigit("52513127000292", 13) == 9
-        assert _hashdigit("52513127000292", 14) == 9
+        self.assertEqual(_hashdigit("00000000000000", 13), 0)
+        self.assertEqual(_hashdigit("00000000000000", 14), 0)
+        self.assertEqual(_hashdigit("52513127000292", 13), 9)
+        self.assertEqual(_hashdigit("52513127000292", 14), 9)
 
     def test__checksum(self):
-        assert _checksum("00000000000000") == "00"
-        assert _checksum("52513127000299") == "99"
+        self.assertEqual(_checksum("00000000000000"), "00")
+        self.assertEqual(_checksum("52513127000299"), "99")
 
 
 if __name__ == "__main__":

--- a/tests/test_cnpj.py
+++ b/tests/test_cnpj.py
@@ -82,8 +82,7 @@ class CNPJ(TestCase):
 
         # When CNPJ is valid
         assert is_valid("34665388000161")
-        assert not is_valid("52599927000100")
-        assert not is_valid("00000000000")
+        assert is_valid("01838723000127")
 
     def test_generate(self):
         for i in range(1000):

--- a/tests/test_cnpj.py
+++ b/tests/test_cnpj.py
@@ -50,6 +50,46 @@ class CNPJ(TestCase):
         assert format_cnpj("0000000000000a") is None
         assert format_cnpj("0000000000000") is None
 
+    def test_validate(self):
+        assert validate("34665388000161")
+        assert not validate("52599927000100")
+        assert not validate("00000000000")
+
+    def test_is_valid(self):
+        # When CNPJ is not string, returns False
+        assert not is_valid(1)
+
+        # When CNPJ's len is different of 14, returns False
+        assert not is_valid("1")
+
+        # When CNPJ does not contain only digits, returns False
+        assert not is_valid("1112223334445-")
+
+        # When CNPJ has only the same digit, returns false
+        assert not is_valid("11111111111111")
+
+        # When rest_1 is lt 2 and the 13th digit is not 0, returns False
+        assert not is_valid("1111111111315")
+
+        # When rest_1 is gte 2 and the 13th digit is not (11 - rest), returns False
+        assert not is_valid("1111111111115")
+
+        # When rest_2 is lt 2 and the 14th digit is not 0, returns False
+        assert not is_valid("11111111121205")
+
+        # When rest_2 is gte 2 and the 14th digit is not (11 - rest), returns False
+        assert not is_valid("11111111113105")
+
+        # When CNPJ is valid
+        assert is_valid("34665388000161")
+        assert not is_valid("52599927000100")
+        assert not is_valid("00000000000")
+
+    def test_generate(self):
+        for i in range(1000):
+            assert validate(generate())
+            assert display(generate()) is not None
+
     def test_hashdigit(self):
         assert hashdigit("00000000000000", 13) == 0
         assert hashdigit("00000000000000", 14) == 0
@@ -59,21 +99,6 @@ class CNPJ(TestCase):
     def test_checksum(self):
         assert checksum("00000000000000") == "00"
         assert checksum("52513127000299") == "99"
-
-    def test_validate(self):
-        assert validate("34665388000161")
-        assert not validate("52599927000100")
-        assert not validate("00000000000")
-
-    def test_is_valid(self):
-        assert is_valid("34665388000161")
-        assert not is_valid("52599927000100")
-        assert not is_valid("00000000000")
-
-    def test_generate(self):
-        for i in range(1000):
-            assert validate(generate())
-            assert display(generate()) is not None
 
 
 if __name__ == "__main__":

--- a/tests/test_cpf.py
+++ b/tests/test_cpf.py
@@ -25,12 +25,14 @@ from unittest import TestCase, main
 
 class CPF(TestCase):
     def test_sieve(self):
-        assert sieve("00000000000") == "00000000000"
-        assert sieve("123.456.789-10") == "12345678910"
-        assert sieve("134..2435.-1892.-") == "13424351892"
-        assert sieve("abc1230916*!*&#") == "abc1230916*!*&#"
-        assert sieve("ab.c1.--.2-309.-1-.6-.*.-!*&#") == "abc1230916*!*&#"
-        assert sieve("...---...") == ""
+        self.assertEqual(sieve("00000000000"), "00000000000")
+        self.assertEqual(sieve("123.456.789-10"), "12345678910")
+        self.assertEqual(sieve("134..2435.-1892.-"), "13424351892")
+        self.assertEqual(sieve("abc1230916*!*&#"), "abc1230916*!*&#")
+        self.assertEqual(
+            sieve("ab.c1.--.2-309.-1-.6-.*.-!*&#"), "abc1230916*!*&#"
+        )
+        self.assertEqual(sieve("...---..."), "")
 
     def test_remove_symbols(self):
         with patch("brutils.cpf.sieve") as mock_sieve:
@@ -39,71 +41,71 @@ class CPF(TestCase):
             mock_sieve.assert_called()
 
     def test_display(self):
-        assert display("00000000011") == "000.000.000-11"
-        assert display("00000000000") is None
-        assert display("0000000000a") is None
-        assert display("000000000000") is None
+        self.assertEqual(display("00000000011"), "000.000.000-11")
+        self.assertIsNone(display("00000000000"))
+        self.assertIsNone(display("0000000000a"))
+        self.assertIsNone(display("000000000000"))
 
     def test_format_cpf(self):
         with patch("brutils.cpf.is_valid", return_value=True) as mock_is_valid:
             # When cpf is_valid, returns formatted cpf
-            assert format_cpf("11144477735") == "111.444.777-35"
+            self.assertEqual(format_cpf("11144477735"), "111.444.777-35")
 
         # Checks if function is_valid_cpf is called
         mock_is_valid.assert_called_once_with("11144477735")
 
         with patch("brutils.cpf.is_valid", return_value=False) as mock_is_valid:
             # When cpf isn't valid, returns None
-            assert format_cpf("11144477735") is None
+            self.assertIsNone(format_cpf("11144477735"))
 
     def test_validate(self):
-        assert validate("52513127765")
-        assert validate("52599927765")
-        assert not validate("00000000000")
+        self.assertTrue(validate("52513127765"))
+        self.assertTrue(validate("52599927765"))
+        self.assertFalse(validate("00000000000"))
 
     def test_is_valid(self):
         # When cpf is not string, returns False
-        assert not is_valid(1)
+        self.assertFalse(is_valid(1))
 
         # When cpf's len is different of 11, returns False
-        assert not is_valid("1")
+        self.assertFalse(is_valid("1"))
 
         # When cpf does not contain only digits, returns False
-        assert not is_valid("1112223334-")
+        self.assertFalse(is_valid("1112223334-"))
 
         # When CPF has only the same digit, returns false
-        assert not is_valid("11111111111")
+        self.assertFalse(is_valid("11111111111"))
 
         # When rest_1 is lt 2 and the 10th digit is not 0, returns False
-        assert not is_valid("11111111215")
+        self.assertFalse(is_valid("11111111215"))
 
         # When rest_1 is gte 2 and the 10th digit is not (11 - rest), returns False
-        assert not is_valid("11144477705")
+        self.assertFalse(is_valid("11144477705"))
 
         # When rest_2 is lt 2 and the 11th digit is not 0, returns False
-        assert not is_valid("11111111204")
+        self.assertFalse(is_valid("11111111204"))
 
         # When rest_2 is gte 2 and the 11th digit is not (11 - rest), returns False
-        assert not is_valid("11144477732")
+        self.assertFalse(is_valid("11144477732"))
 
         # When cpf is valid
-        assert is_valid("11144477735")
-        assert is_valid("11111111200")
+        self.assertTrue(is_valid("11144477735"))
+        self.assertTrue(is_valid("11111111200"))
 
     def test_generate(self):
         for _ in range(10_000):
-            assert validate(generate())
-            assert display(generate()) is not None
+            self.assertTrue(validate(generate()))
+            self.assertIsNotNone(display(generate()))
 
     def test__hashdigit(self):
-        assert _hashdigit("000000000", 10) == 0
-        assert _hashdigit("0000000000", 11) == 0
-        assert _hashdigit("52513127765", 10) == 6
-        assert _hashdigit("52513127765", 11) == 5
+        self.assertEqual(_hashdigit("000000000", 10), 0)
+        self.assertEqual(_hashdigit("0000000000", 11), 0)
+        self.assertEqual(_hashdigit("52513127765", 10), 6)
+        self.assertEqual(_hashdigit("52513127765", 11), 5)
 
     def test_checksum(self):
-        assert _checksum("000000000") == "00"
-        assert _checksum("525131277") == "65"
+        self.assertEqual(_checksum("000000000"), "00")
+        self.assertEqual(_checksum("525131277"), "65")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Arquivos modificados:

- test_cpf;
- test_cnpj;
- test_cep;

Foram ajustados os métodos antigos de teste, para a padronização conforme a documentação do framework utilizado  [unittest](https://docs.python.org/3/library/unittest.html)

closes #144 