### PR TITLE
Refactor: incluindo `Test` no nome das Classes 

### DIFF
--- a/brutils/cnpj.py
+++ b/brutils/cnpj.py
@@ -93,7 +93,7 @@ def is_valid(cnpj):  # type: (str) -> bool
     Using this method name to match with the js library  api.
     Using the same method to ensure backwards compatibility.
     """
-    return validate(cnpj)
+    return isinstance(cnpj, str) and validate(cnpj)
 
 
 def generate(branch=1):  # type: (int) -> str

--- a/tests/test_cep.py
+++ b/tests/test_cep.py
@@ -18,7 +18,7 @@ from brutils.cep import (
 from unittest import TestCase, main
 
 
-class CEP(TestCase):
+class TestCEP(TestCase):
     def test_remove_symbols(self):
         self.assertEqual(remove_symbols("00000000"), "00000000")
         self.assertEqual(remove_symbols("01310-200"), "01310200")

--- a/tests/test_cnpj.py
+++ b/tests/test_cnpj.py
@@ -82,8 +82,7 @@ class CNPJ(TestCase):
 
         # When CNPJ is valid
         assert is_valid("34665388000161")
-        assert not is_valid("52599927000100")
-        assert not is_valid("00000000000")
+        assert is_valid("01838723000127")
 
     def test_generate(self):
         for i in range(1000):

--- a/tests/test_cnpj.py
+++ b/tests/test_cnpj.py
@@ -50,6 +50,46 @@ class CNPJ(TestCase):
         assert format_cnpj("0000000000000a") is None
         assert format_cnpj("0000000000000") is None
 
+    def test_validate(self):
+        assert validate("34665388000161")
+        assert not validate("52599927000100")
+        assert not validate("00000000000")
+
+    def test_is_valid(self):
+        # When CNPJ is not string, returns False
+        assert not is_valid(1)
+
+        # When CNPJ's len is different of 14, returns False
+        assert not is_valid("1")
+
+        # When CNPJ does not contain only digits, returns False
+        assert not is_valid("1112223334445-")
+
+        # When CNPJ has only the same digit, returns false
+        assert not is_valid("11111111111111")
+
+        # When rest_1 is lt 2 and the 13th digit is not 0, returns False
+        assert not is_valid("1111111111315")
+
+        # When rest_1 is gte 2 and the 13th digit is not (11 - rest), returns False
+        assert not is_valid("1111111111115")
+
+        # When rest_2 is lt 2 and the 14th digit is not 0, returns False
+        assert not is_valid("11111111121205")
+
+        # When rest_2 is gte 2 and the 14th digit is not (11 - rest), returns False
+        assert not is_valid("11111111113105")
+
+        # When CNPJ is valid
+        assert is_valid("34665388000161")
+        assert not is_valid("52599927000100")
+        assert not is_valid("00000000000")
+
+    def test_generate(self):
+        for i in range(1000):
+            assert validate(generate())
+            assert display(generate()) is not None
+
     def test_hashdigit(self):
         assert hashdigit("00000000000000", 13) == 0
         assert hashdigit("00000000000000", 14) == 0
@@ -59,21 +99,6 @@ class CNPJ(TestCase):
     def test_checksum(self):
         assert checksum("00000000000000") == "00"
         assert checksum("52513127000299") == "99"
-
-    def test_validate(self):
-        assert validate("34665388000161")
-        assert not validate("52599927000100")
-        assert not validate("00000000000")
-
-    def test_is_valid(self):
-        assert is_valid("34665388000161")
-        assert not is_valid("52599927000100")
-        assert not is_valid("00000000000")
-
-    def test_generate(self):
-        for i in range(1000):
-            assert validate(generate())
-            assert display(generate()) is not None
 
 
 if __name__ == "__main__":

--- a/tests/test_cnpj.py
+++ b/tests/test_cnpj.py
@@ -23,7 +23,7 @@ from brutils.cnpj import (
 from unittest import TestCase, main
 
 
-class CNPJ(TestCase):
+class TestCNPJ(TestCase):
     def test_sieve(self):
         self.assertEqual(sieve("00000000000"), "00000000000")
         self.assertEqual(sieve("12.345.678/0001-90"), "12345678000190")

--- a/tests/test_cpf.py
+++ b/tests/test_cpf.py
@@ -23,7 +23,7 @@ from brutils.cpf import (
 from unittest import TestCase, main
 
 
-class CPF(TestCase):
+class TestCPF(TestCase):
     def test_sieve(self):
         self.assertEqual(sieve("00000000000"), "00000000000")
         self.assertEqual(sieve("123.456.789-10"), "12345678910")


### PR DESCRIPTION
Arquivos modificados:

- test_cnpj;
- test_cpf;
- test_cep;

* ajustados os nomes das classes de teste, que não continham `Test` em sua nomenclatura. 

closes #145 