### PR TITLE
Arrumando links dos badges de downloads dos READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 
 [![codecov](https://codecov.io/gh/brazilian-utils/brutils-python/branch/main/graph/badge.svg?token=5KNECS8JYF)](https://codecov.io/gh/brazilian-utils/brutils-python)
-[![Downloads per Month](https://shields.io/pypi/dm/brutils)](https://pypi.org/project/brutils/)
+[![Downloads per Month](https://shields.io/pypi/dm/brutils)](https://pypistats.org/packages/brutils)
 [![Package version](https://shields.io/pypi/v/brutils)](https://pypi.org/project/brutils/)
 
 ### [Looking for the english version?](README_EN.md)

--- a/README_EN.md
+++ b/README_EN.md
@@ -4,7 +4,7 @@
 <p>Utils library for Brazilian-specific businesses.</p>
 
 [![codecov](https://codecov.io/gh/brazilian-utils/brutils-python/branch/main/graph/badge.svg?token=5KNECS8JYF)](https://codecov.io/gh/brazilian-utils/brutils-python)
-[![Downloads per Month](https://shields.io/pypi/dm/brutils)](https://pypi.org/project/brutils/)
+[![Downloads per Month](https://shields.io/pypi/dm/brutils)](https://pypistats.org/packages/brutils)
 [![Package version](https://shields.io/pypi/v/brutils)](https://pypi.org/project/brutils/)
 ### [Procurando pela versão em português?](README.md)
 ### [Looking for 1.0.1 version documentation?](/documentation%20v1.0.1/ENGLISH_VERSION.md)


### PR DESCRIPTION
<img width="158" alt="image" src="https://github.com/brazilian-utils/brutils-python/assets/2728804/2c5413b2-fa23-4236-ab2e-5b2f6d86d292">

Mudando de: `https://pypi.org/project/brutils/` para: `https://pypistats.org/packages/brutils`

Closes #166 