### PR TITLE
Validar Placa de Carro - Formato Mercosul / PIV (LLLNLNN)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Utilitário `is_valid_mobile_phone` [#146](https://github.com/brazilian-utils/brutils-python/pull/146)
 - Utilitário `is_valid_landline_phone` [#143](https://github.com/brazilian-utils/brutils-python/pull/143)
 - Utilitário `remove_symbols_phone` [#188](https://github.com/brazilian-utils/brutils-python/pull/188)
-- Utilitário `is_valid_license_plate_mercosul` e `is_valid_license_plate_old_format` [#215](https://github.com/brazilian-utils/brutils-python/pull/215)
+- Utilitário `is_valid_license_plate_mercosul` [#215](https://github.com/brazilian-utils/brutils-python/pull/215)
 
 ## [2.0.0] - 2023-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Utilitário `is_valid_mobile_phone` [#146](https://github.com/brazilian-utils/brutils-python/pull/146)
 - Utilitário `is_valid_landline_phone` [#143](https://github.com/brazilian-utils/brutils-python/pull/143)
 - Utilitário `remove_symbols_phone` [#188](https://github.com/brazilian-utils/brutils-python/pull/188)
+- Utilitário `is_valid_license_plate_mercosul` e `is_valid_license_plate_old_format` [#215](https://github.com/brazilian-utils/brutils-python/pull/215)
 
 ## [2.0.0] - 2023-07-23
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ False
   - [is_valid_phone](#is_valid_phone)
   - [is_valid_mobile_phone](#is_valid_mobile_phone)
   - [is_valid_landline_phone](#is_valid_landline_phone)
+- [License Plate](#license_plate)
+  - [is_valid_license_plate_mercosul](#is_valid_license_plate_mercosul)
+  - [is_valid_license_plate_old_format](#is_valid_license_plate_old_format)
+
 
 ## CPF
 
@@ -227,6 +231,32 @@ realmente existe.
 ```python
 >>> from brutils import is_valid_landline_phone
 >>> is_valid_landline_phone('1938814933')
+True
+```
+
+## License_Plate
+
+### is_valid_license_plate_mercosul
+
+Verifica se uma string correspondente a um número da placa é válido, conforme as novas
+normas do Mercosul, isto é, seguindo o padrão LLLNLNN. 
+***Exemplo: ABC4E67.***
+
+```python
+>>> from brutils import is_valid_license_plate_mercosul
+>>> is_valid_license_plate_mercosul('ABC4E67')
+True
+```
+
+### is_valid_license_plate_old_format
+
+Verifica se uma string correspondente a um número da placa é válido, conforme as normas
+anteriores à adesão da norma do Mercosul, isto é, seguindo o padrão LLLNNNN. 
+***Exemplo: ABC4567.***
+
+```python
+>>> from brutils import is_valid_license_plate_old_format
+>>> is_valid_license_plate_old_format('ABC4567')
 True
 ```
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ False
   - [is_valid_email](#is_valid_email)
 - [License Plate](#license_plate)
   - [is_valid_license_plate_mercosul](#is_valid_license_plate_mercosul)
-  - [is_valid_license_plate_old_format](#is_valid_license_plate_old_format)
 
 ## CPF
 
@@ -276,18 +275,6 @@ normas do Mercosul, isto é, seguindo o padrão LLLNLNN.
 ```python
 >>> from brutils import is_valid_license_plate_mercosul
 >>> is_valid_license_plate_mercosul('ABC4E67')
-True
-```
-
-### is_valid_license_plate_old_format
-
-Verifica se uma string correspondente a um número da placa é válido, conforme as normas
-anteriores à adesão da norma do Mercosul, isto é, seguindo o padrão LLLNNNN. 
-***Exemplo: ABC4567.***
-
-```python
->>> from brutils import is_valid_license_plate_old_format
->>> is_valid_license_plate_old_format('ABC4567')
 True
 ```
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -61,6 +61,9 @@ False
   - [is_valid_phone](#is_valid_phone)
   - [is_valid_mobile_phone](#is_valid_mobile_phone)
   - [is_valid_landline_phone](#is_valid_landline_phone)
+- [License Plate](#license_plate)
+  - [is_valid_license_plate_mercosul](#is_valid_license_plate_mercosul)
+  - [is_valid_license_plate_old_format](#is_valid_license_plate_old_format)
 
 
 ## CPF
@@ -224,6 +227,33 @@ Check if landline phone number is valid. Numbers only, with area code (DDD) and 
 ```python
 >>> from brutils import is_valid_landline_phone
 >>> is_valid_landline_phone('1938814933')
+True
+```
+
+## License_Plate
+
+### is_valid_license_plate_mercosul
+
+Checks if the provided string representing a license place is valid, according to the new
+Mercosul standards, in other words, if it follows the pattern LLLNLNN.
+***Example: ABC4E67.***
+
+```python
+>>> from brutils import is_valid_license_plate_mercosul
+>>> is_valid_license_plate_mercosul('ABC4E67')
+True
+```
+
+### is_valid_license_plate_old_format
+
+Checks if the provided string representing a license place is valid, according to the old
+standards prior to the Mercosul adopted recently, in other words, if it follows the
+pattern LLLNNNN.
+***Example: ABC4567.***
+
+```python
+>>> from brutils import is_valid_license_plate_old_format
+>>> is_valid_license_plate_old_format('ABC4567')
 True
 ```
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -66,7 +66,6 @@ False
   - [is_valid_email](#is_valid_email)
 - [License Plate](#license_plate)
   - [is_valid_license_plate_mercosul](#is_valid_license_plate_mercosul)
-  - [is_valid_license_plate_old_format](#is_valid_license_plate_old_format)
 
 
 ## CPF
@@ -272,19 +271,6 @@ Mercosul standards, in other words, if it follows the pattern LLLNLNN.
 ```python
 >>> from brutils import is_valid_license_plate_mercosul
 >>> is_valid_license_plate_mercosul('ABC4E67')
-True
-```
-
-### is_valid_license_plate_old_format
-
-Checks if the provided string representing a license place is valid, according to the old
-standards prior to the Mercosul adopted recently, in other words, if it follows the
-pattern LLLNNNN.
-***Example: ABC4567.***
-
-```python
->>> from brutils import is_valid_license_plate_old_format
->>> is_valid_license_plate_old_format('ABC4567')
 True
 ```
 

--- a/brutils/__init__.py
+++ b/brutils/__init__.py
@@ -22,7 +22,4 @@ from brutils.phone import (
     is_valid as is_valid_phone,
 )
 from brutils.email import is_valid_email as is_valid_email
-from brutils.license_plate import (
-    is_valid_old_format as is_valid_license_plate_old_format,
-    is_valid_mercosul as is_valid_license_plate_mercosul,
-)
+from brutils.license_plate import is_valid_mercosul as is_valid_license_plate_mercosul

--- a/brutils/__init__.py
+++ b/brutils/__init__.py
@@ -21,3 +21,7 @@ from brutils.phone import (
     is_valid_mobile as is_valid_mobile_phone,
     is_valid as is_valid_phone,
 )
+from brutils.license_plate import (
+    is_valid_old_format as is_valid_license_plate_old_format,
+    is_valid_mercosul as is_valid_license_plate_mercosul,
+)

--- a/brutils/__init__.py
+++ b/brutils/__init__.py
@@ -22,4 +22,6 @@ from brutils.phone import (
     is_valid as is_valid_phone,
 )
 from brutils.email import is_valid_email as is_valid_email
-from brutils.license_plate import is_valid_mercosul as is_valid_license_plate_mercosul
+from brutils.license_plate import (
+    is_valid_mercosul as is_valid_license_plate_mercosul,
+)

--- a/brutils/__init__.py
+++ b/brutils/__init__.py
@@ -21,9 +21,9 @@ from brutils.phone import (
     is_valid_mobile as is_valid_mobile_phone,
     is_valid as is_valid_phone,
 )
-from brutils.email import is_valid_email as is_valid_email
 
 from brutils.license_plate import (
     is_valid_mercosul as is_valid_license_plate_mercosul,
 )
 
+from brutils.email import is_valid as is_valid_email

--- a/brutils/license_plate.py
+++ b/brutils/license_plate.py
@@ -1,0 +1,29 @@
+import re
+
+
+def is_valid_mercosul(license_plate):  # type: (str) -> bool
+    """
+    Returns whether or not the provided license_plate is valid according to the
+    Mercosul pattern (LLLNLNN). Input should be a digit string of proper
+    length. Ex: ABC4E67
+    """
+    if not isinstance(license_plate, str):
+        return False
+
+    license_plate = license_plate.upper().strip()
+    pattern = re.compile(r"^[A-Z]{3}\d[A-Z]\d{2}$")
+    return re.match(pattern, license_plate) is not None
+
+
+def is_valid_old_format(license_plate):
+    """
+    Returns whether or not the provided license_plate is valid according to the
+    old Brazilian pattern (LLLNNNN). Input should be a digit string of proper
+    length. Ex: ABC5678
+    """
+    if not isinstance(license_plate, str):
+        return False
+
+    license_plate = license_plate.upper().strip()
+    pattern = re.compile(r"^[A-Z]{3}\d{4}$")
+    return re.match(pattern, license_plate) is not None

--- a/brutils/license_plate.py
+++ b/brutils/license_plate.py
@@ -13,17 +13,3 @@ def is_valid_mercosul(license_plate):  # type: (str) -> bool
     license_plate = license_plate.upper().strip()
     pattern = re.compile(r"^[A-Z]{3}\d[A-Z]\d{2}$")
     return re.match(pattern, license_plate) is not None
-
-
-def is_valid_old_format(license_plate):
-    """
-    Returns whether or not the provided license_plate is valid according to the
-    old Brazilian pattern (LLLNNNN). Input should be a digit string of proper
-    length. Ex: ABC5678
-    """
-    if not isinstance(license_plate, str):
-        return False
-
-    license_plate = license_plate.upper().strip()
-    pattern = re.compile(r"^[A-Z]{3}\d{4}$")
-    return re.match(pattern, license_plate) is not None

--- a/tests/test_license_plate.py
+++ b/tests/test_license_plate.py
@@ -1,7 +1,7 @@
 # from unittest.mock import patch
 
 # from brutils.phone import is_valid_landline, is_valid_mobile, is_valid
-from brutils.license_plate import is_valid_mercosul, is_valid_old_format
+from brutils.license_plate import is_valid_mercosul
 
 from unittest import TestCase, main
 
@@ -36,36 +36,6 @@ class TestLicensePlate(TestCase):
 
         # Check if function is case insensitive
         self.assertIs(is_valid_mercosul("abc4e67"), True)
-
-    def test_is_valid_license_plate_old_format(self):
-        # When license plate is not string, returns False
-        self.assertIs(is_valid_old_format(1234567), False)
-
-        # When license plate doesn't match the pattern LLLNNNN, returns False
-        self.assertIs(is_valid_old_format("ABCDEFG"), False)
-        self.assertIs(is_valid_old_format("1234567"), False)
-        self.assertIs(is_valid_old_format("ABC123"), False)
-        self.assertIs(is_valid_old_format("ABCD234"), False)
-        self.assertIs(is_valid_old_format("ABC12F4"), False)
-        self.assertIs(is_valid_old_format("ABC123G"), False)
-        self.assertIs(is_valid_old_format("ABC123"), False)
-
-        # When license plate is an empty string, returns False
-        self.assertIs(is_valid_old_format(""), False)
-
-        # When license plate's length is different of 7, returns False
-        self.assertIs(is_valid_old_format("ABC12345"), False)
-
-        # When license plate has separator, returns false
-        self.assertIs(is_valid_old_format("ABC-1234"), False)
-
-        # When license plate is valid
-        self.assertIs(is_valid_old_format("ABC4567"), True)
-        self.assertIs(is_valid_old_format("AAA1111"), True)
-        self.assertIs(is_valid_old_format("XXX9999"), True)
-
-        # Check if function is case insensitive
-        self.assertIs(is_valid_old_format("abc4567"), True)
 
 
 if __name__ == "__main__":

--- a/tests/test_license_plate.py
+++ b/tests/test_license_plate.py
@@ -1,0 +1,72 @@
+# from unittest.mock import patch
+
+# from brutils.phone import is_valid_landline, is_valid_mobile, is_valid
+from brutils.license_plate import is_valid_mercosul, is_valid_old_format
+
+from unittest import TestCase, main
+
+
+class TestLicensePlate(TestCase):
+    def test_is_valid_license_plate_mercosul(self):
+        # When license plate is not string, returns False
+        self.assertIs(is_valid_mercosul(1234567), False)
+
+        # When license plate doesn't match the pattern LLLNLNN, returns False
+        self.assertIs(is_valid_mercosul("ABCDEFG"), False)
+        self.assertIs(is_valid_mercosul("1234567"), False)
+        self.assertIs(is_valid_mercosul("ABC4567"), False)
+        self.assertIs(is_valid_mercosul("ABCD567"), False)
+        self.assertIs(is_valid_mercosul("ABC45F7"), False)
+        self.assertIs(is_valid_mercosul("ABC456G"), False)
+        self.assertIs(is_valid_mercosul("ABC123"), False)
+
+        # When license plate is an empty string, returns False
+        self.assertIs(is_valid_mercosul(""), False)
+
+        # When license plate's length is different of 7, returns False
+        self.assertIs(is_valid_mercosul("ABC4E678"), False)
+
+        # When license plate has separator, returns false
+        self.assertIs(is_valid_mercosul("ABC-1D23"), False)
+
+        # When license plate is valid
+        self.assertIs(is_valid_mercosul("ABC4E67"), True)
+        self.assertIs(is_valid_mercosul("AAA1A11"), True)
+        self.assertIs(is_valid_mercosul("XXX9X99"), True)
+
+        # Check if function is case insensitive
+        self.assertIs(is_valid_mercosul("abc4e67"), True)
+
+    def test_is_valid_license_plate_old_format(self):
+        # When license plate is not string, returns False
+        self.assertIs(is_valid_old_format(1234567), False)
+
+        # When license plate doesn't match the pattern LLLNNNN, returns False
+        self.assertIs(is_valid_old_format("ABCDEFG"), False)
+        self.assertIs(is_valid_old_format("1234567"), False)
+        self.assertIs(is_valid_old_format("ABC123"), False)
+        self.assertIs(is_valid_old_format("ABCD234"), False)
+        self.assertIs(is_valid_old_format("ABC12F4"), False)
+        self.assertIs(is_valid_old_format("ABC123G"), False)
+        self.assertIs(is_valid_old_format("ABC123"), False)
+
+        # When license plate is an empty string, returns False
+        self.assertIs(is_valid_old_format(""), False)
+
+        # When license plate's length is different of 7, returns False
+        self.assertIs(is_valid_old_format("ABC12345"), False)
+
+        # When license plate has separator, returns false
+        self.assertIs(is_valid_old_format("ABC-1234"), False)
+
+        # When license plate is valid
+        self.assertIs(is_valid_old_format("ABC4567"), True)
+        self.assertIs(is_valid_old_format("AAA1111"), True)
+        self.assertIs(is_valid_old_format("XXX9999"), True)
+
+        # Check if function is case insensitive
+        self.assertIs(is_valid_old_format("abc4567"), True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Descrição
Implementa as funções básicas de validação de placas no formato antigo e no novo formato do Mercosul.

## Mudanças Propostas
Implementa primeiras funções do novo módulo `license_plate` para validação de placas no formato antigo e no novo formato do Mercosul.

- Função `is_valid_license_plate_old_format` que valida as placas no formato antigo.
- Função `is_valid_license_plate_mercosul` que valida as placas no formato do Mercosul.


## Checklist de Revisão
- [X] Eu li o [Contributing.md](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md)
- [X] Os testes foram adicionados ou atualizados para refletir as mudanças (se aplicável).
- [X] Foi adicionada uma entrada no changelog / Meu PR não necessita de uma nova entrada no changelog.
- [X] A [documentação](https://github.com/brazilian-utils/brutils-python/blob/main/README.md) em português foi atualizada ou criada, se necessário.
- [X] Se feita a documentação, a atualização do [arquivo em inglês](https://github.com/brazilian-utils/brutils-python/blob/main/README_EN.md). <!---Permitido uso de Google Tradutor/ChatGPT. -->
- [X] Eu documentei as minhas mudanças no código, adicionando docstrings e comentários. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#8-fa%C3%A7a-as-suas-altera%C3%A7%C3%B5es)
- [X] O código segue as diretrizes de estilo e padrões de codificação do projeto.
- [X] Todos os testes passam. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#testes)
- [X] O Pull Request foi testado localmente. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#7-execute-o-brutils-localmente)
- [X] Não há conflitos de mesclagem.


## Comentários Adicionais (opcional)

Closes issue #175 