### PR TITLE
format pis #206

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Utilitário `is_valid_license_plate_mercosul` [#215](https://github.com/brazilian-utils/brutils-python/pull/215)
 - Utilitário `convert_license_plate_to_mercosul` [#226](https://github.com/brazilian-utils/brutils-python/pull/226)
 - Utilitário `format_license_plate` [#230](https://github.com/brazilian-utils/brutils-python/pull/230)
-- Utilitário `format_pis` [#206](https://github.com/brazilian-utils/brutils-python/pull/206)
+- Utilitário `format_pis` [#224](https://github.com/brazilian-utils/brutils-python/pull/224)
 
 
 ## [2.0.0] - 2023-07-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Utilitário `is_valid_license_plate_mercosul` [#215](https://github.com/brazilian-utils/brutils-python/pull/215)
 - Utilitário `convert_license_plate_to_mercosul` [#226](https://github.com/brazilian-utils/brutils-python/pull/226)
 - Utilitário `format_license_plate` [#230](https://github.com/brazilian-utils/brutils-python/pull/230)
+- Utilitário `format_pis` [#206](https://github.com/brazilian-utils/brutils-python/pull/206)
 
 
 ## [2.0.0] - 2023-07-23

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ False
 - [PIS](#pis)
   - [is_valid_pis](#is_valid_pis)
   - [generate_pis](#generate_pis)
+  - [format_pis](#format_pis)
 - [Processo Jurídico](#processo-jurídico)
   - [remove\_symbols\_processo\_juridico](#remove_symbols_processo_juridico)
 
@@ -381,6 +382,16 @@ from brutils import generate_pis
 '57817700092'
 >>> generate_pis()
 '49850211630'
+```
+
+### format_pis
+
+Formata o número PIS. Retorna None se o PIS for inválido.
+
+```python
+>>> from brutils import format_pis
+>>> format_pis('12038619494')
+'120.38619.49-4'
 ```
 
 ## Processo Jurídico

--- a/README_EN.md
+++ b/README_EN.md
@@ -74,6 +74,7 @@ False
 - [PIS](#pis)
   - [is_valid_pis](#is_valid_pis)
   - [generate_pis](#generate_pis)
+  - [format_pis](#format_pis)
 - [Legal Process](#legal-process)
   - [remove\_symbols\_processo\_juridico](#remove_symbols_processo_juridico)
 
@@ -383,6 +384,16 @@ from brutils import generate_pis
 '57817700092'
 >>> generate_pis()
 '49850211630'
+```
+
+### format_pis
+
+Format the PIS number. Returns None if the PIS is invalid.
+
+```python
+>>> from brutils import format_pis
+>>> format_pis('12038619494')
+'120.38619.49-4'
 ```
 
 ## Legal Process

--- a/brutils/__init__.py
+++ b/brutils/__init__.py
@@ -37,7 +37,7 @@ from brutils.email import is_valid as is_valid_email
 from brutils.pis import (
     is_valid as is_valid_pis,
     generate as generate_pis,
-    format_pis
+    format_pis,
 )
 
 from brutils.legal_process import (

--- a/brutils/__init__.py
+++ b/brutils/__init__.py
@@ -37,6 +37,7 @@ from brutils.email import is_valid as is_valid_email
 from brutils.pis import (
     is_valid as is_valid_pis,
     generate as generate_pis,
+    format_pis
 )
 
 from brutils.legal_process import (

--- a/brutils/pis.py
+++ b/brutils/pis.py
@@ -78,16 +78,16 @@ def _checksum(base_pis: str) -> int:
 
     return 0 if check_digit in [10, 11] else check_digit
 
-def format_pis(pis: str)  -> str:
+
+def format_pis(pis: str) -> str:
     """
     Format an adequately formatted numbers-only PIS string,
     Returns a PIS formatted with standard visual aid symbols.
     Returns :
         value [str]: PIS formatted
     """
-    
+
     if not is_valid(pis):
-    
         return None
-    
+
     return "{}.{}.{}-{}".format(pis[:3], pis[3:8], pis[8:10], pis[10:11])

--- a/brutils/pis.py
+++ b/brutils/pis.py
@@ -77,3 +77,17 @@ def _checksum(base_pis: str) -> int:
     check_digit = 11 - (pis_sum % 11)
 
     return 0 if check_digit in [10, 11] else check_digit
+
+def format_pis(pis: str)  -> str:
+    """
+    Format an adequately formatted numbers-only PIS string,
+    Returns a PIS formatted with standard visual aid symbols.
+    Returns :
+        value [str]: PIS formatted
+    """
+    
+    if not is_valid(pis):
+    
+        return None
+    
+    return "{}.{}.{}-{}".format(pis[:3], pis[3:8], pis[8:10], pis[10:11])

--- a/tests/test_pis.py
+++ b/tests/test_pis.py
@@ -1,5 +1,5 @@
 from brutils.pis import (
-    validate, 
+    validate,
     is_valid,
     generate,
     _checksum,
@@ -54,14 +54,12 @@ class TestPIS(TestCase):
         for _ in range(10_000):
             self.assertIs(validate(generate()), True)
 
-
     def test_remove_symbols(self):
         self.assertEqual(remove_symbols("00000000000"), "00000000000")
         self.assertEqual(remove_symbols("170.33259.50-4"), "17033259504")
         self.assertEqual(remove_symbols("134..2435/.-1892.-"), "1342435/1892")
         self.assertEqual(remove_symbols("abc1230916*!*&#"), "abc1230916*!*&#")
         self.assertEqual(remove_symbols("...---..."), "")
-
 
     def test_format_pis(self):
         with patch("brutils.pis.is_valid", return_value=True) as mock_is_valid:
@@ -72,6 +70,7 @@ class TestPIS(TestCase):
         with patch("brutils.pis.is_valid", return_value=False) as mock_is_valid:
             # When PIS isn't valid, returns None
             self.assertIsNone(format_pis("14372195539"))
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_pis.py
+++ b/tests/test_pis.py
@@ -1,12 +1,13 @@
 from brutils.pis import (
-  validate, 
-  is_valid,
-  generate,
-  _checksum,
-  remove_symbols,
-  format_pis,
+    validate, 
+    is_valid,
+    generate,
+    _checksum,
+    remove_symbols,
+    format_pis,
 )
 from unittest import TestCase, main
+from unittest.mock import patch
 
 
 class TestPIS(TestCase):

--- a/tests/test_pis.py
+++ b/tests/test_pis.py
@@ -56,7 +56,7 @@ class TestPIS(TestCase):
     def test_generate(self):
         for _ in range(10_000):
             self.assertIs(validate(generate()), True)
-            
+
     def test_format_pis(self):
         with patch("brutils.pis.is_valid", return_value=True) as mock_is_valid:
             # When PIS is_valid, returns formatted PIS
@@ -65,7 +65,7 @@ class TestPIS(TestCase):
         mock_is_valid.assert_called_once_with("14372195539")
         with patch("brutils.pis.is_valid", return_value=False) as mock_is_valid:
             # When PIS isn't valid, returns None
-            self.assertIsNone(format_pis("14372195539")) 
+            self.assertIsNone(format_pis("14372195539"))
 
 
 if __name__ == "__main__":

--- a/tests/test_pis.py
+++ b/tests/test_pis.py
@@ -9,7 +9,7 @@ range = range if version_info.major >= 3 else xrange
 path.insert(
     1, abspath(join(dirname(abspath(getsourcefile(lambda: 0))), pardir))
 )
-from brutils.pis import validate, is_valid, generate, _checksum
+from brutils.pis import validate, is_valid, generate, _checksum, format_pis
 from unittest import TestCase, main
 
 
@@ -56,6 +56,16 @@ class TestPIS(TestCase):
     def test_generate(self):
         for _ in range(10_000):
             self.assertIs(validate(generate()), True)
+            
+    def test_format_pis(self):
+        with patch("brutils.pis.is_valid", return_value=True) as mock_is_valid:
+            # When PIS is_valid, returns formatted PIS
+            self.assertEqual(format_pis("14372195539"), "143.72195.53-9")
+        # Checks if function is_valid_pis is called
+        mock_is_valid.assert_called_once_with("14372195539")
+        with patch("brutils.pis.is_valid", return_value=False) as mock_is_valid:
+            # When PIS isn't valid, returns None
+            self.assertIsNone(format_pis("14372195539")) 
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Descrição

Dada uma String correspondente a um número de PIS válido, retornar uma String correspondendo a este número formatada com pontos e traço.

NNN.NNNNN.NN-D

## Mudanças Propostas
Desenvolvimento das funções de validação e formatação do PIS.


## Checklist de Revisão
<!--- Marque as caixas que se aplicam. Você pode deixar caixas desmarcadas se elas não se aplicarem.-->

- [x] Eu li o [Contributing.md](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md)
- [x] Os testes foram adicionados ou atualizados para refletir as mudanças (se aplicável).
- [x] Foi adicionada uma entrada no changelog / Meu PR não necessita de uma nova entrada no changelog.
- [] A [documentação](https://github.com/brazilian-utils/brutils-python/blob/main/README.md) em português foi atualizada ou criada, se necessário.
- [] Se feita a documentação, a atualização do [arquivo em inglês](https://github.com/brazilian-utils/brutils-python/blob/main/README_EN.md). <!---Permitido uso de Google Tradutor/ChatGPT. -->
- [x] Eu documentei as minhas mudanças no código, adicionando docstrings e comentários. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#8-fa%C3%A7a-as-suas-altera%C3%A7%C3%B5es)
- [x] O código segue as diretrizes de estilo e padrões de codificação do projeto.
- x[] Todos os testes passam. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#testes)
- [x] O Pull Request foi testado localmente. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#7-execute-o-brutils-localmente)
- [x] Não há conflitos de mesclagem.

