### PR TITLE
Conversão de Placa de Carro - Formato Antigo (LLLNNNN) para Formato Mercosul / PIV (LLLNLNN)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Utilitário `is_valid_landline_phone` [#143](https://github.com/brazilian-utils/brutils-python/pull/143)
 - Utilitário `remove_symbols_phone` [#188](https://github.com/brazilian-utils/brutils-python/pull/188)
 - Utilitário `is_valid_license_plate_mercosul` [#215](https://github.com/brazilian-utils/brutils-python/pull/215)
+- Utilitário `convert_license_plate_to_mercosul` [#226](https://github.com/brazilian-utils/brutils-python/pull/226)
+
 
 ## [2.0.0] - 2023-07-23
 

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ False
   - [remove_symbols_phone](#remove_symbols_phone)
 - [Email](#email)
   - [is_valid_email](#is_valid_email)
-- [License_Plate](#license_plate)
-  - [is_valid_license_plate_old_format](#is_valid_license_plate_old_format)
 - [License Plate](#license_plate)
+  - [is_valid_license_plate_old_format](#is_valid_license_plate_old_format)
   - [is_valid_license_plate_mercosul](#is_valid_license_plate_mercosul)
+  - [convert_license_plate_to_mercosul](#convert_license_plate_to_mercosul)
 
 ## CPF
 
@@ -314,6 +314,23 @@ normas do Mercosul, isto é, seguindo o padrão LLLNLNN.
 >>> from brutils import is_valid_license_plate_mercosul
 >>> is_valid_license_plate_mercosul('ABC4E67')
 True
+```
+
+### convert_license_plate_to_mercosul
+
+Converte uma string correspondente a um número da placa é válido no formato antigo,
+para o novo formato, conforme as novas normas do Mercosul (seguindo o padrão LLLNLNN).
+Caso a placa informada seja inválida será retornado o valor `None`.
+***Exemplo: ABC4567 -> ABC4F67.***
+
+```python
+>>> from brutils import convert_license_plate_to_mercosul
+>>> convert_license_plate_to_mercosul("ABC123")
+"ABC1C34"
+>>> convert_license_plate_to_mercosul("abc123")
+"ABC1C34"
+>>> convert_license_plate_to_mercosul("ABC1D23")
+None
 ```
 
 # Novos Utilitários e Reportar Bugs

--- a/README_EN.md
+++ b/README_EN.md
@@ -64,10 +64,10 @@ False
   - [remove_symbols_phone](#remove_symbols_phone)
 - [Email](#email)
   - [is_valid_email](#is_valid_email)
-- [License_Plate](#license_plate)
-  - [is_valid_license_plate_old_format](#is_valid_license_plate_old_format)
 - [License Plate](#license_plate)
+  - [is_valid_license_plate_old_format](#is_valid_license_plate_old_format)
   - [is_valid_license_plate_mercosul](#is_valid_license_plate_mercosul)
+  - [convert_license_plate_to_mercosul](#convert_license_plate_to_mercosul)
 
 
 ## CPF
@@ -289,6 +289,23 @@ Mercosul standards, in other words, if it follows the pattern LLLNLNN.
 >>> from brutils import is_valid_license_plate_mercosul
 >>> is_valid_license_plate_mercosul('ABC4E67')
 True
+```
+
+### convert_license_plate_to_mercosul
+
+Converts the provided string representing a license plate in the old format to the new
+format, according to the new Mercosul standards (following the pattern LLLNLNN). In case
+the provided license plate is invalid it will return the value `None`.
+***Example: ABC4567 -> ABC4F67.***
+
+```python
+>>> from brutils import convert_license_plate_to_mercosul
+>>> convert_license_plate_to_mercosul("ABC123")
+"ABC1C34"
+>>> convert_license_plate_to_mercosul("abc123")
+"ABC1C34"
+>>> convert_license_plate_to_mercosul("ABC1D23")
+None
 ```
 
 # Feature Request and Bug Report

--- a/brutils/__init__.py
+++ b/brutils/__init__.py
@@ -24,6 +24,7 @@ from brutils.phone import (
 
 from brutils.license_plate import (
     is_valid_mercosul as is_valid_license_plate_mercosul,
+    convert_to_mercosul as convert_license_plate_to_mercosul,
 )
 
 from brutils.email import is_valid as is_valid_email

--- a/brutils/license_plate.py
+++ b/brutils/license_plate.py
@@ -11,9 +11,6 @@ def is_valid_license_plate_old_format(plate: str) -> bool:
     )
 
 
-import re
-
-
 def is_valid_mercosul(license_plate):  # type: (str) -> bool
     """
     Returns whether or not the provided license_plate is valid according to the
@@ -26,3 +23,25 @@ def is_valid_mercosul(license_plate):  # type: (str) -> bool
     license_plate = license_plate.upper().strip()
     pattern = re.compile(r"^[A-Z]{3}\d[A-Z]\d{2}$")
     return re.match(pattern, license_plate) is not None
+
+
+def convert_to_mercosul(license_plate):
+    """
+    Receives a old pattern license plate (LLLNNNN) and returns a Mercosul
+    converted license plate (LLLNLNN). pattern (LLLNLNN). Input should be
+    a digit string of proper length. In case of an invalid license plate
+    it will return 'None'.
+    Ex: ABC4567 - > ABC4F67
+        ABC4*67 - > 'None'
+    """
+    if not is_valid_license_plate_old_format(license_plate):
+        return None
+
+    digits = [letter for letter in license_plate.upper()]
+    try:
+        digit = int(digits[4])
+    except ValueError:
+        return None
+
+    digits[4] = chr(ord("A") + digit)
+    return "".join(digits)

--- a/brutils/license_plate.py
+++ b/brutils/license_plate.py
@@ -38,10 +38,5 @@ def convert_to_mercosul(license_plate):
         return None
 
     digits = [letter for letter in license_plate.upper()]
-    try:
-        digit = int(digits[4])
-    except ValueError:
-        return None
-
-    digits[4] = chr(ord("A") + digit)
+    digits[4] = chr(ord("A") + int(digits[4]))
     return "".join(digits)

--- a/tests/test_license_plate.py
+++ b/tests/test_license_plate.py
@@ -1,7 +1,4 @@
-# from unittest.mock import patch
-
-# from brutils.phone import is_valid_landline, is_valid_mobile, is_valid
-from brutils.license_plate import is_valid_mercosul
+from brutils.license_plate import is_valid_mercosul, convert_to_mercosul
 
 from unittest import TestCase, main
 
@@ -36,6 +33,47 @@ class TestLicensePlate(TestCase):
 
         # Check if function is case insensitive
         self.assertIs(is_valid_mercosul("abc4e67"), True)
+
+    def test_convert_license_plate_to_mercosul(self):
+        # when license plate is not an instance of string, returns None
+        self.assertIsNone(convert_to_mercosul(1234567))
+
+        # when license plate has a length different from 7, returns None
+        self.assertIsNone(convert_to_mercosul("ABC123"))
+        self.assertIsNone(convert_to_mercosul("ABC12356"))
+
+        # when then license plate's 5th character is not a number, return None
+        self.assertIsNone(convert_to_mercosul("ABC1A34"))
+        self.assertIsNone(convert_to_mercosul("ABC1-34"))
+        self.assertIsNone(convert_to_mercosul("ABC1*34"))
+        self.assertIsNone(convert_to_mercosul("ABC1_34"))
+        self.assertIsNone(convert_to_mercosul("ABC1%34"))
+        self.assertIsNone(convert_to_mercosul("ABC1 34"))
+
+        # when then license plate's 5th character is 0, return with a letter A
+        self.assertEqual(convert_to_mercosul("AAA1011"), "AAA1A11")
+        # when then license plate's 5th character is 1, return with a letter B
+        self.assertEqual(convert_to_mercosul("AAA1111"), "AAA1B11")
+        # when then license plate's 5th character is 2, return with a letter C
+        self.assertEqual(convert_to_mercosul("AAA1211"), "AAA1C11")
+        # when then license plate's 5th character is 3, return with a letter D
+        self.assertEqual(convert_to_mercosul("AAA1311"), "AAA1D11")
+        # when then license plate's 5th character is 4, return with a letter E
+        self.assertEqual(convert_to_mercosul("AAA1411"), "AAA1E11")
+        # when then license plate's 5th character is 5, return with a letter F
+        self.assertEqual(convert_to_mercosul("AAA1511"), "AAA1F11")
+        # when then license plate's 5th character is 6, return with a letter G
+        self.assertEqual(convert_to_mercosul("AAA1611"), "AAA1G11")
+        # when then license plate's 5th character is 7, return with a letter H
+        self.assertEqual(convert_to_mercosul("AAA1711"), "AAA1H11")
+        # when then license plate's 5th character is 8, return with a letter I
+        self.assertEqual(convert_to_mercosul("AAA1811"), "AAA1I11")
+        # when then license plate's 5th character is 9, return with a letter J
+        self.assertEqual(convert_to_mercosul("AAA1911"), "AAA1J11")
+
+        # when then license is provided in lowercase, it's correctly converted
+        # and then returned value is in uppercase
+        self.assertEqual(convert_to_mercosul("abc1234"), "ABC1C34")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Descrição
Adiciona a função `convert_license_plate_to_mercosul` ao módulo license_plate, bem como sua documentação e suite de testes.

## Mudanças Propostas
Implementa a função de conversão de formatos de placa, do velho formato (LLLNNNN) para o formato do Mercosul (LLLNLNN).

- Função `convert_license_plate_to_mercosul` quer converte entre formatos.


## Checklist de Revisão
- [x] Eu li o [Contributing.md](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md)
- [x] Os testes foram adicionados ou atualizados para refletir as mudanças (se aplicável).
- [x] Foi adicionada uma entrada no changelog / Meu PR não necessita de uma nova entrada no changelog.
- [x] A [documentação](https://github.com/brazilian-utils/brutils-python/blob/main/README.md) em português foi atualizada ou criada, se necessário.
- [x] Se feita a documentação, a atualização do [arquivo em inglês](https://github.com/brazilian-utils/brutils-python/blob/main/README_EN.md). <!---Permitido uso de Google Tradutor/ChatGPT. -->
- [x] Eu documentei as minhas mudanças no código, adicionando docstrings e comentários. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#8-fa%C3%A7a-as-suas-altera%C3%A7%C3%B5es)
- [x] O código segue as diretrizes de estilo e padrões de codificação do projeto.
- [x] Todos os testes passam. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#testes)
- [x] O Pull Request foi testado localmente. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#7-execute-o-brutils-localmente)
- [x] Não há conflitos de mesclagem.

## Comentários Adicionais (opcional)

## Issue Relacionada
Closes #177 
