### PR TITLE
Formatar Placa de Carro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Utilitário `remove_symbols_phone` [#188](https://github.com/brazilian-utils/brutils-python/pull/188)
 - Utilitário `is_valid_license_plate_mercosul` [#215](https://github.com/brazilian-utils/brutils-python/pull/215)
 - Utilitário `convert_license_plate_to_mercosul` [#226](https://github.com/brazilian-utils/brutils-python/pull/226)
+- Utilitário `format_license_plate` [#230](https://github.com/brazilian-utils/brutils-python/pull/230)
 
 
 ## [2.0.0] - 2023-07-23

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ False
   - [is_valid_license_plate_old_format](#is_valid_license_plate_old_format)
   - [is_valid_license_plate_mercosul](#is_valid_license_plate_mercosul)
   - [convert_license_plate_to_mercosul](#convert_license_plate_to_mercosul)
+  - [format_license_plate](#format_license_plate)
 - [PIS](#pis)
   - [is_valid_pis](#is_valid_pis)
   - [generate_pis](#generate_pis)
@@ -318,6 +319,27 @@ Caso a placa informada seja inválida será retornado o valor `None`.
 >>> convert_license_plate_to_mercosul("abc123")
 "ABC1C34"
 >>> convert_license_plate_to_mercosul("ABC1D23")
+None
+```
+
+### format_license_plate
+
+Dada uma String correspondente a uma placa de carro válida, seja no formato da placa
+é o antigo (LLLNNNN) ou o novo Formato Mercosul (LLLNLNN), retornar uma String
+correspondendo a esta placa formatada com o traço para o formato antigo e sem mudança para
+o formato Mercosul.
+***Exemplo: ABC4567 -> ABC4F67.***
+
+```python
+>>> format_license_plate("ABC1234")
+"ABC-1234"
+>>> format_license_plate("abc1234")
+"ABC-1234"
+>>> format_license_plate("ABC1D23")
+"ABC1D23"
+>>> format_license_plate("abc1d23")
+"ABC1D23"
+>>> format_license_plate("ABCD123")
 None
 ```
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -68,6 +68,7 @@ False
   - [is_valid_license_plate_old_format](#is_valid_license_plate_old_format)
   - [is_valid_license_plate_mercosul](#is_valid_license_plate_mercosul)
   - [convert_license_plate_to_mercosul](#convert_license_plate_to_mercosul)
+  - [format_license_plate](#format_license_plate)
 - [PIS](#pis)
   - [is_valid_pis](#is_valid_pis)
   - [generate_pis](#generate_pis)
@@ -309,6 +310,28 @@ the provided license plate is invalid it will return the value `None`.
 >>> convert_license_plate_to_mercosul("abc123")
 "ABC1C34"
 >>> convert_license_plate_to_mercosul("ABC1D23")
+None
+```
+
+### format_license_plate
+
+Given a String corresponding to valid license plate, whether following the old Brazilian
+pattern (LLLNNNN) or the new Mercosul pattern (LLLNLNN), return a new String corresponding
+to the formatted license plate with a dash (-) for the old format or in upper case for the
+Mercosul format.
+***Exemplo: ABC1234 -> ABC-1234.***
+            ABC1E34 -> ABC1E34.***
+
+```python
+>>> format_license_plate("ABC1234")
+"ABC-1234"
+>>> format_license_plate("abc1234")
+"ABC-1234"
+>>> format_license_plate("ABC1D23")
+"ABC1D23"
+>>> format_license_plate("abc1d23")
+"ABC1D23"
+>>> format_license_plate("ABCD123")
 None
 ```
 

--- a/brutils/__init__.py
+++ b/brutils/__init__.py
@@ -29,6 +29,7 @@ from brutils.license_plate import (
     is_valid_mercosul as is_valid_license_plate_mercosul,
     is_valid_license_plate_old_format,
     convert_to_mercosul as convert_license_plate_to_mercosul,
+    format as format_license_plate,
 )
 
 from brutils.email import is_valid as is_valid_email

--- a/brutils/license_plate.py
+++ b/brutils/license_plate.py
@@ -21,6 +21,23 @@ def convert_to_mercosul(license_plate):
     return "".join(digits)
 
 
+def format(license_plate):
+    """
+    Receives a license plate in any pattern (LLLNNNN or LLLNLNN) and returns a
+    formatted version, with a dash (-) for the old pattern, in upper case for
+    them Mercosul pattern and 'None' for an invalid license plate.
+    Ex: ABC1234 - > ABC-1234
+        abc1e34 - > ABC1E34
+        ABC123  - > 'None'
+    """
+    license_plate = license_plate.upper()
+    if is_valid_license_plate_old_format(license_plate):
+        return license_plate[0:3] + "-" + license_plate[3:]
+    elif is_valid_mercosul(license_plate):
+        return license_plate.upper()
+    return None
+
+
 # OPERATIONS
 ############
 

--- a/tests/test_license_plate.py
+++ b/tests/test_license_plate.py
@@ -2,6 +2,7 @@ from brutils.license_plate import (
     is_valid_license_plate_old_format,
     is_valid_mercosul,
     convert_to_mercosul,
+    format,
 )
 
 from unittest import TestCase, main
@@ -99,6 +100,13 @@ class TestLicensePlate(TestCase):
         # when then license is provided in lowercase, it's correctly converted
         # and then returned value is in uppercase
         self.assertEqual(convert_to_mercosul("abc1234"), "ABC1C34")
+
+    def test_format_license_plate(self):
+        self.assertEqual(format("ABC1234"), "ABC-1234")
+        self.assertEqual(format("abc1234"), "ABC-1234")
+        self.assertEqual(format("ABC1D23"), "ABC1D23")
+        self.assertEqual(format("abc1d23"), "ABC1D23")
+        self.assertIsNone(format("ABCD123"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Descrição
Adiciona a função `format_license_plate` que recebe uma placa de carro em qualquer formato válido e a retorna formatada, isto é, para o padrão antigo retorna com a adição do traço (-) e para o padrão Mercosul retorna sua versão em caixa alta. Para placas inválidas é retornado `None`.

## Mudanças Propostas
Implementa função de formatação de placas de carro.

- Função `format_license_plate`

## Checklist de Revisão

- [X] Eu li o [Contributing.md](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md)
- [X] Os testes foram adicionados ou atualizados para refletir as mudanças (se aplicável).
- [X] Foi adicionada uma entrada no changelog / Meu PR não necessita de uma nova entrada no changelog.
- [X] A [documentação](https://github.com/brazilian-utils/brutils-python/blob/main/README.md) em português foi atualizada ou criada, se necessário.
- [X] Se feita a documentação, a atualização do [arquivo em inglês](https://github.com/brazilian-utils/brutils-python/blob/main/README_EN.md). <!---Permitido uso de Google Tradutor/ChatGPT. -->
- [X] Eu documentei as minhas mudanças no código, adicionando docstrings e comentários. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#8-fa%C3%A7a-as-suas-altera%C3%A7%C3%B5es)
- [X] O código segue as diretrizes de estilo e padrões de codificação do projeto.
- [X] Todos os testes passam. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#testes)
- [X] O Pull Request foi testado localmente. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#7-execute-o-brutils-localmente)
- [X] Não há conflitos de mesclagem.


## Comentários Adicionais (opcional)

## Issue Relacionada
Closes #180 
