### PR TITLE
Gerar Placa de Carro Aleatória e Válida

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Utilitário `is_valid_license_plate_mercosul` [#215](https://github.com/brazilian-utils/brutils-python/pull/215)
 - Utilitário `convert_license_plate_to_mercosul` [#226](https://github.com/brazilian-utils/brutils-python/pull/226)
 - Utilitário `format_license_plate` [#230](https://github.com/brazilian-utils/brutils-python/pull/230)
+- Utilitário `generate_license_plate` [#241](https://github.com/brazilian-utils/brutils-python/pull/241)
 
 
 ## [2.0.0] - 2023-07-23

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ False
   - [convert_license_plate_to_mercosul](#convert_license_plate_to_mercosul)
   - [format_license_plate](#format_license_plate)
   - [remove\_symbols\_license\_plate](#remove_symbols_license_plate)
+  - [generate_license_plate](#generate_license_plate)
 - [PIS](#pis)
   - [is_valid_pis](#is_valid_pis)
   - [generate_pis](#generate_pis)
@@ -376,6 +377,25 @@ from brutils import remove_symbols_license_plate
 "ABCD123"
 >>> remove_symbols_license_plate("@abc#-#123@")
 "@abc##123@"
+```
+
+### generate_license_plate
+
+Gera placas válidas de carro utilizando como parâmetro um dos formatos válidos (LLLNLNN ou
+LLLNNNN), tendo como formato padrão o padrão Mercosul. Caso seja fornecido um formato
+inválido, é retornado o valor `None`.
+
+```python
+from brutils import generate_license_plate
+
+>>> generate_license_plate()
+"ABC1D23"
+>>> generate_license_plate(format="LLLNLNN")
+"ABC4D56"
+>>> generate_license_plate(format="LLLNNNN")
+"ABC123"
+>>> generate_license_plate(format="invalid")
+None
 ```
 
 ## PIS

--- a/README_EN.md
+++ b/README_EN.md
@@ -71,6 +71,7 @@ False
   - [convert_license_plate_to_mercosul](#convert_license_plate_to_mercosul)
   - [format_license_plate](#format_license_plate)
   - [remove\_symbols\_license\_plate](#remove_symbols_license_plate)
+  - [generate_license_plate](#generate_license_plate)
 - [PIS](#pis)
   - [is_valid_pis](#is_valid_pis)
   - [generate_pis](#generate_pis)
@@ -370,6 +371,24 @@ from brutils import remove_symbols_license_plate
 "ABCD123"
 >>> remove_symbols_license_plate("@abc#-#123@")
 "@abc##123@"
+```
+
+### generate_license_plate
+
+Generate random valid license plates using a provided pattern (LLLNLNN or LLLNNNN), having
+as default the Mercosul pattern. When provided an invalid pattern `None` is returned.
+
+```python
+from brutils import generate_license_plate
+
+>>> generate_license_plate()
+"ABC1D23"
+>>> generate_license_plate(format="LLLNLNN")
+"ABC4D56"
+>>> generate_license_plate(format="LLLNNNN")
+"ABC123"
+>>> generate_license_plate(format="invalid")
+None
 ```
 
 ## PIS

--- a/brutils/license_plate.py
+++ b/brutils/license_plate.py
@@ -98,8 +98,6 @@ def generate(format="LLLNLNN"):  # type: (str) -> str | None
     for char in format:
         if char == "L":
             generated += choice(ascii_uppercase)
-        elif char == "N":
-            generated += str(randint(0, 9))
         else:
-            raise Exception(f"Format character unkown: '{char}'")
+            generated += str(randint(0, 9))
     return generated

--- a/brutils/license_plate.py
+++ b/brutils/license_plate.py
@@ -1,5 +1,8 @@
 import re
 
+from random import choice, randint
+from string import ascii_uppercase
+
 # FORMATTING
 ############
 
@@ -85,3 +88,18 @@ def remove_symbols(license_plate_number: str):  # type: (str) -> str
                     [str]: A license plate string without symbols
     """
     return license_plate_number.replace("-", "")
+
+
+def generate(format="LLLNLNN"):  # type: (str) -> str | None
+    generated = ""
+    format = format.upper()
+    if format not in ("LLLNLNN", "LLLNNNN"):
+        return None
+    for char in format:
+        if char == "L":
+            generated += choice(ascii_uppercase)
+        elif char == "N":
+            generated += str(randint(0, 9))
+        else:
+            raise Exception(f"Format character unkown: '{char}'")
+    return generated

--- a/brutils/license_plate.py
+++ b/brutils/license_plate.py
@@ -110,7 +110,8 @@ def get_format(license_plate: str) -> Optional[str]:
         return "LLLNLNN"
 
     return None
-  
+from random import choice, randint
+from string import ascii_uppercase
 def generate(format="LLLNLNN"):  # type: (str) -> str | None
     generated = ""
     format = format.upper()

--- a/brutils/license_plate.py
+++ b/brutils/license_plate.py
@@ -1,5 +1,7 @@
 import re
 from typing import Optional
+from random import choice, randint
+from string import ascii_uppercase
 
 # FORMATTING
 ############
@@ -110,9 +112,13 @@ def get_format(license_plate: str) -> Optional[str]:
         return "LLLNLNN"
 
     return None
-from random import choice, randint
-from string import ascii_uppercase
+
+
 def generate(format="LLLNLNN"):  # type: (str) -> str | None
+    """
+    Generate a valid license plate in the given format. In case no format is
+    provided, it will return a license plate in the Mercosul format.
+    """
     generated = ""
     format = format.upper()
     if format not in ("LLLNLNN", "LLLNNNN"):
@@ -123,4 +129,3 @@ def generate(format="LLLNLNN"):  # type: (str) -> str | None
         else:
             generated += str(randint(0, 9))
     return generated
-

--- a/brutils/license_plate.py
+++ b/brutils/license_plate.py
@@ -111,7 +111,7 @@ def get_format(license_plate: str) -> Optional[str]:
 
     return None
   
-  def generate(format="LLLNLNN"):  # type: (str) -> str | None
+def generate(format="LLLNLNN"):  # type: (str) -> str | None
     generated = ""
     format = format.upper()
     if format not in ("LLLNLNN", "LLLNNNN"):
@@ -122,3 +122,4 @@ def get_format(license_plate: str) -> Optional[str]:
         else:
             generated += str(randint(0, 9))
     return generated
+

--- a/tests/test_license_plate.py
+++ b/tests/test_license_plate.py
@@ -8,7 +8,7 @@ from brutils.license_plate import (
     get_format,
     generate,
 )
-
+from unittest.mock import patch
 from unittest import TestCase, main
 
 

--- a/tests/test_license_plate.py
+++ b/tests/test_license_plate.py
@@ -154,7 +154,7 @@ class TestLicensePlate(TestCase):
         self.assertIsNone(get_format("ABC-1D23"))
         self.assertIsNone(get_format("invalid plate"))
         
-     def test_generate_license_plate(self):
+    def test_generate_license_plate(self):
         with patch("brutils.license_plate.choice", return_value="X"):
             with patch("brutils.license_plate.randint", return_value=9):
                 self.assertEqual(generate(format="LLLNNNN"), "XXX9999")

--- a/tests/test_license_plate.py
+++ b/tests/test_license_plate.py
@@ -5,8 +5,10 @@ from brutils.license_plate import (
     is_valid,
     convert_to_mercosul,
     format,
+    generate,
 )
 
+from unittest.mock import patch
 from unittest import TestCase, main
 
 
@@ -136,6 +138,26 @@ class TestLicensePlate(TestCase):
         self.assertEqual(format("ABC1D23"), "ABC1D23")
         self.assertEqual(format("abc1d23"), "ABC1D23")
         self.assertIsNone(format("ABCD123"))
+
+    def test_generate_license_plate(self):
+        with patch("brutils.license_plate.choice", return_value="X"):
+            with patch("brutils.license_plate.randint", return_value=9):
+                self.assertEqual(generate(format="LLLNNNN"), "XXX9999")
+                self.assertEqual(generate(format="LLLNLNN"), "XXX9X99")
+
+        for _ in range(10_000):
+            self.assertTrue(is_valid_mercosul(generate(format="LLLNLNN")))
+
+        for _ in range(10_000):
+            self.assertTrue(
+                is_valid_license_plate_old_format(generate(format="LLLNNNN"))
+            )
+
+        # When no format is provided, returns a valid Mercosul license plate
+        self.assertTrue(is_valid_mercosul(generate()))
+
+        # When invalid format is provided, returns None
+        self.assertIsNone(generate("LNLNLNL"))
 
 
 if __name__ == "__main__":

--- a/tests/test_license_plate.py
+++ b/tests/test_license_plate.py
@@ -153,7 +153,7 @@ class TestLicensePlate(TestCase):
         self.assertIsNone(get_format(""))
         self.assertIsNone(get_format("ABC-1D23"))
         self.assertIsNone(get_format("invalid plate"))
-        
+
     def test_generate_license_plate(self):
         with patch("brutils.license_plate.choice", return_value="X"):
             with patch("brutils.license_plate.randint", return_value=9):
@@ -173,6 +173,7 @@ class TestLicensePlate(TestCase):
 
         # When invalid format is provided, returns None
         self.assertIsNone(generate("LNLNLNL"))
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Descrição
Adiciona a funcionalidade responsável por gerar placas válidas de carro, podendo especificar o formato: antigo (LLLNNNN) ou o novo Formato Mercosul / PIV (LLLNLNN).

## Mudanças Propostas
Implementa a função de gerar placas aleatórias.

- Função `generate_license_plate`


## Checklist de Revisão
- [x] Eu li o [Contributing.md](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md)
- [x] Os testes foram adicionados ou atualizados para refletir as mudanças (se aplicável).
- [x] Foi adicionada uma entrada no changelog / Meu PR não necessita de uma nova entrada no changelog.
- [x] A [documentação](https://github.com/brazilian-utils/brutils-python/blob/main/README.md) em português foi atualizada ou criada, se necessário.
- [x] Se feita a documentação, a atualização do [arquivo em inglês](https://github.com/brazilian-utils/brutils-python/blob/main/README_EN.md). <!---Permitido uso de Google Tradutor/ChatGPT. -->
- [x] Eu documentei as minhas mudanças no código, adicionando docstrings e comentários. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#8-fa%C3%A7a-as-suas-altera%C3%A7%C3%B5es)
- [x] O código segue as diretrizes de estilo e padrões de codificação do projeto.
- [x] Todos os testes passam. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#testes)
- [x] O Pull Request foi testado localmente. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#7-execute-o-brutils-localmente)
- [x] Não há conflitos de mesclagem.


## Comentários Adicionais (opcional)

## Issue Relacionada
Closes #181 