### PR TITLE
Fix code scanning alert

### DIFF
--- a/brutils/license_plate.py
+++ b/brutils/license_plate.py
@@ -52,13 +52,14 @@ def is_valid(license_plate: str) -> bool:
     ) or is_valid_mercosul(license_plate)
 
 
-def is_valid_license_plate_old_format(plate: str) -> bool:
+def is_valid_license_plate_old_format(license_plate: str) -> bool:
     """
     Checks whether a string matches the old format of Brazilian license plate.
     """
-    pattern = re.compile(r"^[aA-zZ]{3}[0-9]{4}$")
+    pattern = re.compile(r"^[A-Za-z]{3}[0-9]{4}$")
     return (
-        isinstance(plate, str) and re.match(pattern, plate.strip()) is not None
+        isinstance(license_plate, str)
+        and re.match(pattern, license_plate.strip()) is not None
     )
 
 

--- a/tests/test_license_plate.py
+++ b/tests/test_license_plate.py
@@ -37,7 +37,7 @@ class TestLicensePlate(TestCase):
         self.assertTrue(is_valid("ABC4E67"))
         self.assertTrue(is_valid("XXX9X99"))
 
-    def test_is_valid_license_old_format(self):
+    def test_is_valid_license_plate_old_format(self):
         # When license plate is valid, returns True
         self.assertTrue(is_valid_license_plate_old_format("ABC1234"))
         self.assertTrue(is_valid_license_plate_old_format("abc1234"))


### PR DESCRIPTION
## Descrição
Tracking issue for:

 https://github.com/brazilian-utils/brutils-python/security/code-scanning/1

## Mudanças Propostas



## Checklist de Revisão
<!--- Marque as caixas que se aplicam. Você pode deixar caixas desmarcadas se elas não se aplicarem.-->

- [x] Eu li o [Contributing.md](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md)
- [x] Os testes foram adicionados ou atualizados para refletir as mudanças (se aplicável).
- [x] Foi adicionada uma entrada no changelog / Meu PR não necessita de uma nova entrada no changelog.
- [x] A [documentação](https://github.com/brazilian-utils/brutils-python/blob/main/README.md) em português foi atualizada ou criada, se necessário.
- [x] Se feita a documentação, a atualização do [arquivo em inglês](https://github.com/brazilian-utils/brutils-python/blob/main/README_EN.md). <!---Permitido uso de Google Tradutor/ChatGPT. -->
- [x] Eu documentei as minhas mudanças no código, adicionando docstrings e comentários. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#8-fa%C3%A7a-as-suas-altera%C3%A7%C3%B5es)
- [x] O código segue as diretrizes de estilo e padrões de codificação do projeto.
- [x] Todos os testes passam. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#testes)
- [x] O Pull Request foi testado localmente. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#7-execute-o-brutils-localmente)
- [x] Não há conflitos de mesclagem.


## Comentários Adicionais (opcional)
<!--- Adicione qualquer informação adicional ou contexto que você acha importante para os revisores entenderem suas mudanças.-->

## Issue Relacionada
<!---Todos os PRs devem ter uma issue relacionada. Dessa forma, podemos garantir que ninguém perca tempo trabalhando em algo que não precisa ser feito. -->


Closes #238 
