### PR TITLE
Padronizando docstrings e ajustando README's

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,30 +59,31 @@ False
   - [remove_symbols_cep](#remove_symbols_cep)
   - [generate_cep](#generate_cep)
 - [Phone](#phone)
-  - [format_phone](#format_phone)
   - [is_valid_phone](#is_valid_phone)
+  - [format_phone](#format_phone)
   - [remove_symbols_phone](#remove_symbols_phone)
+  - [remove_international_dialing_code](#remove_international_dialing_code)
   - [generate_phone](#generate_phone)
-  - [remove_international_code_phone](#remove_international_code_phone)
 - [Email](#email)
   - [is_valid_email](#is_valid_email)
 - [Placa de Carro](#placa-de-carro)
   - [is_valid_license_plate](#is_valid_license_plate)
-  - [convert_license_plate_to_mercosul](#convert_license_plate_to_mercosul)
   - [format_license_plate](#format_license_plate)
-  - [remove\_symbols\_license\_plate](#remove_symbols_license_plate)
-  - [get_license_plate_format](#get_license_plate_format)
+  - [remove_symbols_license_plate](#remove_symbols_license_plate)
   - [generate_license_plate](#generate_license_plate)
+  - [convert_license_plate_to_mercosul](#convert_license_plate_to_mercosul)
+  - [get_license_plate_format](#get_license_plate_format)
 - [PIS](#pis)
   - [is_valid_pis](#is_valid_pis)
-  - [generate_pis](#generate_pis)
-  - [remove_symbols_pis](#remove_symbols_pis)
   - [format_pis](#format_pis)
+  - [remove_symbols_pis](#remove_symbols_pis)
+  - [generate_pis](#generate_pis)
 - [Processo Jurídico](#processo-jurídico)
-  - [format_legal_process](#format_legal_process)
-  - [remove\_symbols\_processo\_juridico](#remove_symbols_legal_process)
-  - [generate_legal_process](#generate_legal_process)
   - [is_valid_legal_process](#is_valid_legal_process)
+  - [format_legal_process](#format_legal_process)
+  - [remove_symbols_legal_process](#remove_symbols_legal_process)
+  - [generate_legal_process](#generate_legal_process)
+
 - [Título Eleitoral](#titulo-eleitoral)
   - [is_valid_voter_id](#is_valid_voter_id)
 
@@ -113,7 +114,7 @@ False
 
 ### format_cpf
 
-Formate um CPF (Cadastro de Pessoa Física brasileiro) para exibição visual.
+Formata um CPF (Cadastro de Pessoa Física brasileiro) para exibição visual.
 Esta função recebe uma string de CPF contendo apenas números como entrada e
 adiciona símbolos de formatação padrão para exibição.
 
@@ -208,8 +209,7 @@ Argumentos:
   * cnpj (str): A string de CNPJ a ser formatada para exibição.
 
 Retorna:
-  * str: O CNPJ formatado com símbolos visuais se for válido,
-         None se não for válido.
+  * str: O CNPJ formatado com símbolos visuais se for válido, None se não for válido.
 
 Exemplo:
 
@@ -355,15 +355,63 @@ Exemplo:
 >>> from brutils import generate_cep
 >>> generate_cep()
 '77520503'
+>>> generate_cep()
+'29641407'
 ```
 
 ## Phone
 
-### format_phone
-Formata um numero de telefone recebido para um formato apresentavel humanamente. Caso não seja um numero válido, retorna `None`
-***Exemplo: 11994029275 será formatado para (11)99402-9275***
+### is_valid_phone
+
+Retorna se um número de telefone brasileiro é válido conforme o formato da string.
+Não verifica se o número realmente existe.
+
+```
+is_valid_phone(phone_number, type)
+```
+
+Argumentos:
+  * phone_number (str):
+    * o número de telefone a ser validado 
+    * apenas dígitos, sem símbolos
+    * sem o código do país
+    * deve incluir o número de DDD com dois dígitos
+    * exemplo: '+55 48 9999 9999' deve ser utilizado como '4899999999'
+    * obrigatório
+
+  * type (str):
+    * 'mobile' para validar apenas números de celular
+    * 'landline' para validar apenas números de telefone fixo
+    * caso não especificado, valida para um para o outro.
+    * opcional
+
+Retorna:
+  * bool: True se o número é válido, False caso contrário.
+
+Exemplo:
 
 ```python
+>>> from brutils import is_valid_phone
+>>> is_valid_phone('11994029275')
+True
+>>> is_valid_phone('11994029275', 'mobile')
+True
+>>> is_valid_phone('1938814933', 'landline')
+True
+```
+
+### format_phone
+Formata um número de telefone para exibição visual. Esta função recebe uma string representando um número de telefone contendo apenas números como entrada e adiciona símbolos de formatação padrão para exibição.
+
+Argumentos:
+  * phone (str): Uma string representando um número de telefone.
+
+Retorna:
+  * str: O número de telefone formatado para exibição ou None se não for válido.
+
+Exemplo:
+```python
+>>> from brutils import format_phone
 >>> format_phone("11994029275")
 '(11)99402-9275'
 >>> format_phone("1635014415")
@@ -372,55 +420,51 @@ Formata um numero de telefone recebido para um formato apresentavel humanamente.
 >>>
 ```
 
-### is_valid_phone
-
-Retornar se um número de telefone brasileiro é valido.
-Não verifica se o número realmente existe.
-
-```
-is_valid_phone(phone_number, type)
-```
-
-Argumentos
-  - phone_number (str):
-    * o número de telefone a ser validado
-    * obrigatório
-    * apenas dígitos, sem símbolos
-    * sem o código do país
-    * deve incluir o número de DDD com dois dígitos
-    * exemplo: '+55 48 9999 9999' deve ser utilizado como '4899999999'
-
-  - type (str):
-    * 'mobile' para validar apenas números de celular
-    * 'landline' para validar apenas números de telefone fixo
-    * caso não especificado, valida para um para o outro.
-    * opcional
-
-Retorno
-  - bool: True se o número é válido, False caso contrário.
-
-Example
-
-```python
->>> from brutils import is_valid_phone
->>> is_valid_phone('11994029275')
-True
->>> is_valid_mobile_phone('11994029275', 'mobile')
-True
->>> is_valid_landline_phone('1938814933', 'landline')
-True
-```
-
 ### remove_symbols_phone
 
-Remove símbolos do número de telefone. ***Exemplo: (21)2569-6969 ficaria '2125696969'.***
+Remove símbolos do número de telefone. Esta função recebe um número de telefone como entrada e remove todos os símbolos, como parênteses '()', traços '-' e espaços ' '.
 
+Argumentos:
+  * phone (str): O número de telefone de entrada que contém os símbolos a serem removidos.
+
+Retorna:
+  * str: Uma nova string com os símbolos especificados removidos.
+
+Exemplo:
 ```python
 >>> from brutils import remove_symbols_phone
 >>> remove_symbols_phone('(21)2569-6969')
 '2125696969'
+>>> remove_symbols_phone('11 9999-8888')
+'1199998888'
+>>> remove_symbols_phone('333333')
+'333333'
 ```
 
+### remove_international_dialing_code
+
+Remove o código internacional (+55) de uma string que contém um número de telefone brasileiro, mantendo outros caracteres especiais.
+
+Argumentos:
+  * phone (str): O número de telefone de entrada que pode conter o código internacional.
+
+Retorna:
+  * str: Uma nova string sem o código internacional, preservando outros caracteres especiais.
+
+Exemplo:
+```python
+>>> from brutils import remove_international_dialing_code
+>>> remove_international_dialing_code("5521994029275")
+"21994029275"
+>>> remove_international_dialing_code("+5521994029275")
+"+21994029275"
+>>> remove_international_dialing_code("5555994029275")
+"55994029275"
+>>> remove_international_dialing_code("21994029275")
+"21994029275"
+>>> remove_international_dialing_code("(+55)21994029275")
+"(+)21994029275"
+```
 
 ### generate_phone
 
@@ -444,23 +488,6 @@ Exemplo:
 "1899115895"
 >>> generate_phone("landline")
 "5535317900"
-```
-
-### remove_international_code_phone
-
-Remove o código internacional (+55) de uma string que contém um número de telefone brasileiro.
-
-```python
->>> from brutils import remove_international_code_phone
->>> remove_international_code_phone("5521994029275")
-"21994029275"
->>> remove_international_code_phone("+5521994029275")
-"+21994029275"
->>> remove_international_code_phone("5555994029275")
-"55994029275"
->>> remove_international_code_phone("21994029275")
-"21994029275"
->>>
 ```
 
 ## Email
@@ -496,8 +523,8 @@ False
 ### is_valid_license_plate
 
 Verifica se uma placa de carro é válida.
-Esta função não verifica se a placa de carro é uma placa de carro real;
-ela apenas valida o formato da string.
+Esta função não verifica se a placa de carro é uma placa de carro real,
+apenas valida o formato da string.
 
 Argumentos:
   * license_plate (str): Uma string representando uma placa de carro.
@@ -523,18 +550,96 @@ True
 False
 ```
 
-### convert_license_plate_to_mercosul
+### format_license_plate
 
-Converte uma placa de carro no formato antigo (LLLNNNN) para o formato Mercosul
-(LLLNLNN).
+Formata uma placa de carro no padrão correto.
+Esta função recebe uma placa de carro em qualquer formato (LLLNNNN ou LLLNLNN) e retorna uma versão formatada.
 
 Argumentos:
-  * license_plate (str): Uma string com o tamanho adequado que representa a
-                         placa no formato antigo.
+  * license_plate (str): Uma string representando uma placa de carro.
 
 Retorna:
-  * str: A placa Mercosul convertida (LLLNLNN) ou
+  * str: A string da placa de carro formatada ou
          'None' se a entrada for inválida.
+
+Exemplo:
+
+```python
+>>> from brutils import format_license_plate
+>>> format_license_plate("ABC1234") 
+"ABC-1234"
+# formato antigo (contém traço)
+>>> format_license_plate("abc1234") 
+"ABC-1234"
+# formato antigo (contém traço)
+>>> format_license_plate("ABC1D23") 
+"ABC1D23"
+# formato mercosul
+>>> format_license_plate("abc1d23") 
+"ABC1D23"
+# formato mercosul
+>>> format_license_plate("ABCD123")
+None
+```
+
+### remove_symbols_license_plate
+
+Remove o símbolo de hífen (-) de uma string de placa de carro.
+
+Argumentos:
+  * license_plate_number (str): Uma string de placa de carro contendo símbolos a serem removidos.
+
+Retorna:
+  * str: A string da placa de carro com os símbolos especificados removidos.
+
+Exemplo:
+
+```python
+from brutils import remove_symbols_license_plate
+>>> remove_symbols_license_plate("ABC-123")
+"ABC123"
+>>> remove_symbols_license_plate("abc123")
+"abc123"
+>>> remove_symbols_license_plate("ABCD123")
+"ABCD123"
+>>> remove_symbols_license_plate("@abc#-#123@")
+"@abc##123@"
+```
+
+### generate_license_plate
+
+Gera uma placa de carro válida no formato especificado. Caso nenhum formato seja fornecido, ele retornará uma placa de carro no formato Mercosul.
+
+Argumentos:
+  * format (str): O formato desejado para a placa de carro. 'LLLNNNN' para o formato antigo ou 'LLLNLNN' para o formato Mercosul. O padrão é 'LLLNLNN'.
+
+Retorna:
+  * str: Um número de placa de carro gerado aleatoriamente ou
+   None se o formato for inválido.
+
+Exemplo:
+
+```python
+from brutils import generate_license_plate
+>>> generate_license_plate()
+"ABC1D23"
+>>> generate_license_plate(format="LLLNLNN")
+"ABC4D56"
+>>> generate_license_plate(format="LLLNNNN")
+"ABC123"
+>>> generate_license_plate(format="invalid")
+None
+```
+
+### convert_license_plate_to_mercosul
+
+Converte uma placa de carro no formato antigo (LLLNNNN) para o formato Mercosul (LLLNLNN).
+
+Argumentos:
+  * license_plate(str): Uma string com o tamanho adequado que representa a placa no formato antigo.
+
+Retorna:
+  * str: A placa Mercosul convertida (LLLNLNN) ou None se a entrada for inválida.
 
 Exemplo:
 
@@ -546,62 +651,6 @@ Exemplo:
 "ABC1C34"
 >>> convert_license_plate_to_mercosul("ABC1D23")
 None
-```
-
-### format_license_plate
-
-Formata uma placa de carro no padrão correto.
-Esta função recebe uma placa de carro em qualquer formato (LLLNNNN ou LLLNLNN)
-e retorna uma versão formatada.
-
-Argumentos:
-  * license_plate (str): Uma string representando uma placa de carro.
-
-Retorna:
-  * str: A string da placa de carro formatada ou
-         'None' se a entrada for inválida.
-
-Exemplo:
-
-
-```python
->>> from brutils import format_license_plate
->>> format_license_plate("ABC1234") # formato antigo (contém traço)
-"ABC-1234"
->>> format_license_plate("abc1234") # formato antigo (contém traço)
-"ABC-1234"
->>> format_license_plate("ABC1D23") # formato mercosul
-"ABC1D23"
->>> format_license_plate("abc1d23") # formato mercosul
-"ABC1D23"
->>> format_license_plate("ABCD123")
-None
-```
-
-### remove_symbols_license_plate
-
-Remove o símbolo de hífen (-) de uma string de placa de carro.
-
-Argumentos:
-  * license_plate_number (str): Uma string de placa de carro contendo símbolos a
-                              serem removidos.
-
-Retorna:
-  * str: A string da placa de carro com os símbolos especificados removidos.
-
-Exemplo:
-
-```python
-from brutils import remove_symbols_license_plate
-
->>> remove_symbols_license_plate("ABC-123")
-"ABC123"
->>> remove_symbols_license_plate("abc123")
-"abc123"
->>> remove_symbols_license_plate("ABCD123")
-"ABCD123"
->>> remove_symbols_license_plate("@abc#-#123@")
-"@abc##123@"
 ```
 
 ### get_license_plate_format
@@ -620,7 +669,6 @@ Exemplo:
 
 ```python
 from brutils import get_license_plate_format
-
 >>> get_license_plate_format("ABC123")
 "LLLNNNN"
 >>> get_license_plate_format("abc123")
@@ -632,80 +680,120 @@ from brutils import get_license_plate_format
 >>> get_license_plate_format("ABCD123")
 None
 ```
-### generate_license_plate
-
-Gere uma placa de carro válida no formato especificado. Caso nenhum formato seja
-fornecido, ele retornará uma placa de carro no formato Mercosul.
-
-Argumentos:
-  * format (str): O formato desejado para a placa de carro. 'LLLNNNN' para o
-  formato antigo ou 'LLLNLNN' para o formato Mercosul. O padrão é 'LLLNLNN'.
-
-Retorna:
-  * str: Um número de placa de carro gerado aleatoriamente ou
-         'None' se o formato for inválido.
-
-Exemplo:
-
-```python
-from brutils import generate_license_plate
-
->>> generate_license_plate()
-"ABC1D23"
->>> generate_license_plate(format="LLLNLNN")
-"ABC4D56"
->>> generate_license_plate(format="LLLNNNN")
-"ABC123"
->>> generate_license_plate(format="invalid")
-None
-````
 
 ## PIS
 
 ### is_valid_pis
 
-Verifica se o número PIS/PASEP é valido. Apenas números, formatados como string. Não verifica se o PIS/PASEP existe.
-Mais detalhes sobre a validação estão disponíveis em https://www.macoratti.net/alg_pis.htm.
+Verifica se o número PIS/PASEP é valido. Apenas números, formatados como string. Não verifica se o PIS/PASEP realmente existe.
 
-### generate_pis
+Referências:
+  - https://www.macoratti.net/alg_pis.htm.
 
-Gera um PIS/PASEP válido aleatório.
+Argumentos:
+  * pis (str): Número PIS como uma string com o comprimento apropriado.
+
+Retorna:
+  * bool: True se o PIS for válido, False caso contrário.
+
+Exemplo:
+```python
+from brutils import is_valid_pis
+>>> is_valid_pis("82178537464")
+False
+>>> is_valid_pis("12082043519")
+True
+```
+
+### format_pis
+
+Formata uma string de PIS (Programa de Integração Social) válida com símbolos e adiciona símbolos de formatação padrão para exibição.
+
+Argumentos:
+  * pis (str): Uma string válida de PIS contendo apenas números.
+
+Retorna:
+  * str: Uma string de PIS formatada com símbolos visuais padrão ou None se a entrada for inválida.
+
+Exemplo:
 
 ```python
-from brutils import generate_pis
-
->>> generate_pis()
-'12038619494'
->>> generate_pis()
-'57817700092'
->>> generate_pis()
-'49850211630'
+from brutils import format_pis
+>>> format_pis("17033259504")
+'170.33259.50-4'
+>>> format_pis("12013128292")
+'120.13128.29-2'
 ```
 
 ### remove_symbols_pis
 
-Remove símbolos "-" e "." de formatação de um número PIS/PASEP. Propositalmente não remove outros símbolos.
+Esta função recebe uma string de PIS (Programa de Integração Social) com símbolos de formatação e retorna uma versão limpa sem símbolos. Remove apenas os símbolos "-" e "." , propositalmente não remove outros símbolos.
+
+Argumentos:
+  * pis (str): Uma string de PIS que pode conter símbolos de formatação.
+
+Retorna:
+  * str: Uma string de PIS limpa, sem símbolos de formatação.
+
+Exemplo:
 
 ```python
 from brutils import remove_symbols_pis
 
 >>> remove_symbols_pis('170.33259.50-4')
 '17033259504'
+>>> remove_symbols_pis("123.456.789-09")
+'12345678909'
 >>> remove_symbols_pis('/._')
 '/_'
 ```
 
-### format_pis
+### generate_pis
 
-Formata o número PIS. Retorna None se o PIS for inválido.
+Gera uma string de dígitos contendo um número de um PIS brasileiro válido aleatório.
+
+Retorna:
+  * str: Um número PIS válido gerado aleatoriamente como string.
+
+Exemplo:
 
 ```python
->>> from brutils import format_pis
->>> format_pis('12038619494')
-'120.38619.49-4'
+from brutils import generate_pis
+>>> generate_pis()
+'61352489741'
+>>> generate_pis()
+'73453349671'
 ```
 
 ## Processo Jurídico
+
+## is_valid_legal_process
+
+Verifica se um ID de processo jurídico é válido, não verifica se o ID de processo jurídico é um ID de processo
+jurídico real; ela apenas valida o formato da string.
+
+Argumentos:
+  * legal_process_id (str): Uma string contendo apenas dígitos que representa
+                            o ID do processo jurídico.
+
+Retorna:
+  * bool: True se o ID do processo jurídico for válido, False caso
+          contrário.
+
+Examplo:
+
+```python
+>>> from brutils import is_valid_legal_process
+>>> is_valid_legal_process('10188748220234018200')
+True
+>>> is_valid_legal_process('45532346920234025107')
+True
+>>> is_valid_legal_process('00000000000000000000')
+False
+>>> is_valid_legal_process('455323423QQWEQWSsasd&*(()')
+False
+>>>
+```
 
 ### format_legal_process
 
@@ -715,7 +803,7 @@ Argumentos:
   * legal_process_id (str): Uma string de 20 dígitos que representa o ID do
                             processo jurídico.
 
-Returna:
+Retorna:
   * str: O ID do processo jurídico formatado ou None se a entrada for inválida.
 
 Exemplo:
@@ -740,14 +828,13 @@ Argumentos:
   * legal_process (str): Um processo jurídico contendo símbolos a serem
                          removidos.
 
-Returna:
+Retorna:
   * str: A string do processo jurídico com os símbolos especificados removidos.
 
 Exemplo:
 
 ```python
 from brutils import remove_symbols_legal_process
-
 >>> remove_symbols_legal_process("6439067-89.2023.4.04.5902")
 "64390678920234045902"
 >>> remove_symbols_legal_process("4976023-82.2012.7.00.2263")
@@ -758,7 +845,7 @@ from brutils import remove_symbols_legal_process
 
 ### generate_legal_process
 
-Gere um número aleatório de ID de processo jurídico.
+Gera um número válido aleatório de ID de processo jurídico.
 
 Argumentos:
   * year (int): O ano para o ID do processo jurídico (o padrão é o ano atual).
@@ -766,7 +853,7 @@ Argumentos:
   * orgao (int): O órgão (1-9) para o ID do processo jurídico
                  (o padrão é aleatório).
 
-Returna:
+Retorna:
   * str: Um ID de processo jurídico gerado aleatoriamente.
          None caso algum dos argumento seja inválido.
 
@@ -784,42 +871,11 @@ Exemplo:
 "33158248820244017105"
 ```
 
-## is_valid_legal_process
-
-Verifique se um ID de processo jurídico é válido.
-
-Esta função não verifica se o ID de processo jurídico é um ID de processo
-jurídico real; ela apenas valida o formato da string.
-
-Argumentos:
-  * legal_process_id (str): Uma string contendo apenas dígitos que representa
-                            o ID do processo jurídico.
-
-Returna:
-  * bool: True se o ID do processo jurídico for válido, False caso
-          contrário.
-
-Examplo:
-
-```python
->>> from brutils import is_valid_legal_process
->>> is_valid_legal_process('10188748220234018200')
-True
->>> is_valid_legal_process('45532346920234025107')
-True
->>> is_valid_legal_process('00000000000000000000')
-False
->>> is_valid_legal_process('455323423QQWEQWSsasd&*(()')
-False
->>>
-```
-
 ## Titulo Eleitoral
 
 ### is_valid_voter_id
 
-Verifique se um número de título de eleitor brasileiro é válido. Não verifica se
-o título de eleitor realmente existe.
+Verifica se um número de título de eleitor brasileiro é válido. Não verifica se realmente existe.
 
 Referências:
   - https://pt.wikipedia.org/wiki/T%C3%ADtulo_de_eleitor

--- a/README_EN.md
+++ b/README_EN.md
@@ -57,30 +57,31 @@ False
   - [remove_symbols_cep](#remove_symbols_cep)
   - [generate_cep](#generate_cep)
 - [Phone](#phone)
-  - [format_phone](#format_phone)
   - [is_valid_phone](#is_valid_phone)
+  - [format_phone](#format_phone)
   - [remove_symbols_phone](#remove_symbols_phone)
+  - [remove_international_dialing_code](#remove_international_dialing_code)
   - [generate_phone](#generate_phone)
-  - [remove_international_code_phone](#remove_international_code_phone)
 - [Email](#email)
   - [is_valid_email](#is_valid_email)
 - [License_Plate](#license-plate)
   - [is_valid_license_plate](#is_valid_license_plate)
-  - [convert_license_plate_to_mercosul](#convert_license_plate_to_mercosul)
   - [format_license_plate](#format_license_plate)
-  - [remove\_symbols\_license\_plate](#remove_symbols_license_plate)
-  - [get_license_plate_format](#get_license_plate_format)
+  - [remove_symbols_license_plate](#remove_symbols_license_plate)
   - [generate_license_plate](#generate_license_plate)
+  - [convert_license_plate_to_mercosul](#convert_license_plate_to_mercosul)
+  - [get_license_plate_format](#get_license_plate_format)
 - [PIS](#pis)
   - [is_valid_pis](#is_valid_pis)
-  - [generate_pis](#generate_pis)
+  - [format_pis](#format_pis)  
   - [remove_symbols_pis](#remove_symbols_pis)
-  - [format_pis](#format_pis)
+  - [generate_pis](#generate_pis)
 - [Legal Process](#legal-process)
+  - [is_valid_legal_process](#is_valid_legal_process)  
   - [format_legal_process](#format_legal_process)
-  - [remove\_symbols\_processo\_juridico](#remove_symbols_legal_process)
+  - [remove_symbols_legal_process](#remove_symbols_legal_process)
   - [generate_legal_process](#generate_legal_process)
-  - [is_valid_legal_process](#is_valid_legal_process)
+
 - [Voter ID](#voter-id)
   - [is_valid_voter_id](#is_valid_voter_id)
 
@@ -284,6 +285,10 @@ Example:
 >>> from brutils import is_valid_cep
 >>> is_valid_cep('01310200')
 True
+>>> is_valid_cep("12345")
+False
+>>> is_valid_cep("abcdefgh")
+False
 ```
 
 ### format_cep
@@ -350,20 +355,6 @@ Example:
 
 ## Phone
 
-### format_phone
-Formats a given phone number to a human-presentable format. If it is not a valid number, returns `None`
-***Example: 11994029275 will be formatted to (11)99402-9275***
-
-
-```python
->>> format_phone("11994029275")
-'(11)99402-9275'
->>> format_phone("1635014415")
-'(16)3501-4415'
->>> format_phone("333333")
->>>
-```
-
 ### is_valid_phone
 
 Return whether a Brazilian phone number is valid.
@@ -373,25 +364,25 @@ It does not verify if the number actually exists.
 is_valid_phone(phone_number, type)
 ```
 
-Args
-  - phone_number:
+Args:
+  * phone_number:
     * the phone number to be validated
-    * mandatory
     * digits only, no symbols
     * without the country code
     * should include the area code (DDD) with two digits
     * example: '+55 48 9999 9999' should be used as '4899999999'
+    * mandatory
 
-  - type:
+  * type:
     * 'mobile' to validate only mobile numbers
     * 'landline' to validate only landline phone numbers
     * if not specified, it validates for either.
     * optional
 
-Return
-  - bool: True if the phone number is valid. False otherwise.
+Returns:
+  * bool: True if the phone number is valid. False otherwise.
 
-Example
+Example:
 
 ```python
 >>> from brutils import is_valid_phone
@@ -403,16 +394,75 @@ True
 True
 ```
 
+### format_phone
+
+Format a phone number for visual display. This function takes a string representing a phone number containing only numbers as input and adds standard formatting symbols for display.
+
+Args:
+  * phone (str): A string representing a phone number.
+
+Returns:
+  * str: The formatted phone number for display or None if it is not valid.
+
+Example:
+
+```python
+>>> from brutils import format_phone
+>>> format_phone("11994029275")
+'(11)99402-9275'
+>>> format_phone("1635014415")
+'(16)3501-4415'
+>>> format_phone("333333")
+>>>
+```
+
 ### remove_symbols_phone
 
-Remove symbols from phone number. ***Example: +55 (21) 2569-6969 will return '552125696969'.***
+Remove symbols from the phone number. This function takes a phone number as input and removes all symbols, such as parentheses '()', dashes '-', and spaces ' '.
+
+Args:
+  * phone (str): The input phone number containing the symbols to be removed.
+
+Returns:
+  * str: A new string with the specified symbols removed.
+
+Example:
 
 ```python
 >>> from brutils import remove_symbols_phone
->>> remove_symbols_phone('+55 (21) 2569-6969')
-'552125696969'
+>>> remove_symbols_phone('(21)2569-6969')
+'2125696969'
+>>> remove_symbols_phone('11 9999-8888')
+'1199998888'
+>>> remove_symbols_phone('333333')
+'333333'
 ```
 
+### remove_international_dialing_code
+
+Remove the international code (+55) from a string containing a Brazilian phone number, preserving other special characters.
+
+Args:
+  * phone (str): The input phone number that may contain the international code.
+
+Returns:
+  * str: A new string without the international code, preserving other special characters.
+
+Example:
+
+```python
+>>> from brutils import remove_international_dialing_code
+>>> remove_international_dialing_code("5521994029275")
+"21994029275"
+>>> remove_international_dialing_code("+5521994029275")
+"+21994029275"
+>>> remove_international_dialing_code("5555994029275")
+"55994029275"
+>>> remove_international_dialing_code("21994029275")
+"21994029275"
+>>> remove_international_dialing_code("(+55)21994029275")
+"(+)21994029275"
+```
 
 ### generate_phone
 
@@ -436,23 +486,6 @@ Example:
 "1899115895"
 >>> generate_phone("landline")
 "5535317900"
-```
-
-### remove_international_code_phone
-
-Remove the international code (+55) from a string that contains a Brazilian phone number.
-
-```python
->>> from brutils import remove_international_code_phone
->>> remove_international_code_phone("5521994029275")
-"21994029275"
->>> remove_international_code_phone("+5521994029275")
-"+21994029275"
->>> remove_international_code_phone("5555994029275")
-"55994029275"
->>> remove_international_code_phone("21994029275")
-"21994029275"
->>>
 ```
 
 ## Email
@@ -514,53 +547,90 @@ True
 False
 ```
 
-### is_valid_license_plate_old_format
+### format_license_plate
 
-Checks whether a string matches the old format of Brazilian license plate
-(LLLNNNN).
-This function does not verify if the license plate is a real license plate;
-it only validates the format of the string.
+Formats a license plate into the correct pattern.
+This function receives a license plate in any pattern (LLLNNNN or LLLNLNN)
+and returns a formatted version.
 
 Args:
   * license_plate (str): A license plate string.
 
 Returns:
-  * bool: True if the string corresponds to a license plate in the old
-          pattern format, False otherwise.
+  * str: The formatted license plate string or
+         'None' if the input is invalid.
 
 Example:
 
 ```python
->>> from brutils import is_valid_license_plate_old_format
->>> is_valid_license_plate_old_format('ABC1234')
-True
->>> is_valid_license_plate_old_format('def5678')
-True
->>> is_valid_license_plate_old_format('GHI-4567')
-False
+>>> from brutils import format_license_plate
+>>> format_license_plate("ABC1234") 
+"ABC-1234"
+# old format (contains a dash)
+>>> format_license_plate("abc1234") 
+"ABC-1234"
+# old format (contains a dash)
+>>> format_license_plate("ABC1D23") 
+"ABC1D23"
+# mercosul format
+>>> format_license_plate("abc1d23") 
+"ABC1D23"
+# mercosul format
+>>> format_license_plate("ABCD123")
+None
 ```
 
-### is_valid_license_plate_mercosul
+### remove_symbols_license_plate
 
-Checks whether a string matches the Mercosul license plate format (LLLNNNN).
-This function does not verify if the license plate is a real license plate;
-it only validates the format of the string.
+Removes the dash (-) symbol from a license plate string.
 
 Args:
-  * license_plate (str): A license plate string.
+  * license_plate_number (str): A license plate number containing symbols to
+                                be removed.
 
 Returns:
-  * bool: True if the string corresponds to a license plate in the Mercosul
-          pattern format, False otherwise.
+  * str: The license plate number with the specified symbols removed.
 
 Example:
 
 ```python
->>> from brutils import is_valid_license_plate_mercosul
->>> is_valid_license_plate_mercosul('ABC4E67')
-True
->>> is_valid_license_plate_mercosul('abc167')
-False
+from brutils import remove_symbols_license_plate
+>>> remove_symbols_license_plate("ABC-123")
+"ABC123"
+>>> remove_symbols_license_plate("abc123")
+"abc123"
+>>> remove_symbols_license_plate("ABCD123")
+"ABCD123"
+>>> remove_symbols_license_plate("@abc#-#123@")
+"@abc##123@"
+```
+
+### generate_license_plate
+
+Generate a valid license plate in the given format. In case no format is
+provided, it will return a license plate in the Mercosul format.
+
+Args:
+  * format (str): The desired format for the license plate.
+                  'LLLNNNN' for the old pattern or 'LLLNLNN' for the
+                   Mercosul one. Default is 'LLLNLNN'
+
+Returns:
+  * str: A randomly generated license plate number or
+         'None' if the format is invalid.
+
+Example:
+
+```python
+from brutils import generate_license_plate
+>>> generate_license_plate()
+"ABC1D23"
+>>> generate_license_plate(format="LLLNLNN")
+"ABC4D56"
+>>> generate_license_plate(format="LLLNNNN")
+"ABC123"
+>>> generate_license_plate(format="invalid")
+None
 ```
 
 ### convert_license_plate_to_mercosul
@@ -588,61 +658,6 @@ Example:
 None
 ```
 
-### format_license_plate
-
-Formats a license plate into the correct pattern.
-This function receives a license plate in any pattern (LLLNNNN or LLLNLNN)
-and returns a formatted version.
-
-Args:
-  * license_plate (str): A license plate string.
-
-Returns:
-  * str: The formatted license plate string or
-         'None' if the input is invalid.
-
-Example:
-
-```python
->>> from brutils import format_license_plate
->>> format_license_plate("ABC1234") # old format (contains a dash)
-"ABC-1234"
->>> format_license_plate("abc1234") # old format (contains a dash)
-"ABC-1234"
->>> format_license_plate("ABC1D23") # mercosul format
-"ABC1D23"
->>> format_license_plate("abc1d23") # mercosul format
-"ABC1D23"
->>> format_license_plate("ABCD123")
-None
-```
-
-### remove_symbols_license_plate
-
-Removes the dash (-) symbol from a license plate string.
-
-Args:
-  * license_plate_number (str): A license plate number containing symbols to
-                                be removed.
-
-Returns:
-  * str: The license plate number with the specified symbols removed.
-
-Example:
-
-```python
-from brutils import remove_symbols_license_plate
-
->>> remove_symbols_license_plate("ABC-123")
-"ABC123"
->>> remove_symbols_license_plate("abc123")
-"abc123"
->>> remove_symbols_license_plate("ABCD123")
-"ABCD123"
->>> remove_symbols_license_plate("@abc#-#123@")
-"@abc##123@"
-```
-
 ### get_license_plate_format
 
 Return the format of a license plate. 'LLLNNNN' for the old pattern and
@@ -659,7 +674,6 @@ Example:
 
 ```python
 from brutils import get_license_plate_format
-
 >>> get_license_plate_format("ABC123")
 "LLLNNNN"
 >>> get_license_plate_format("abc123")
@@ -671,92 +685,121 @@ from brutils import get_license_plate_format
 >>> get_license_plate_format("ABCD123")
 None
 ```
-### generate_license_plate
-
-Generate a valid license plate in the given format. In case no format is
-provided, it will return a license plate in the Mercosul format.
-
-Args:
-  * format (str): The desired format for the license plate.
-                  'LLLNNNN' for the old pattern or 'LLLNLNN' for the
-                   Mercosul one. Default is 'LLLNLNN'
-
-Returns:
-  * str: A randomly generated license plate number or
-         'None' if the format is invalid.
-
-Example:
-
-```python
-from brutils import generate_license_plate
-
->>> generate_license_plate()
-"ABC1D23"
->>> generate_license_plate(format="LLLNLNN")
-"ABC4D56"
->>> generate_license_plate(format="LLLNNNN")
-"ABC123"
->>> generate_license_plate(format="invalid")
-None
-```
 
 ## PIS
 
 ### is_valid_pis
 
-Check if PIS/PASEP number is valid. Numbers only, formatted as strings. Does not check if PIS/PASEP exists.
-More details about the validation can be found here: https://www.macoratti.net/alg_pis.htm.
+Verifies if the PIS/PASEP number is valid. Only numbers, formatted as a string. It does not check if the PIS/PASEP actually exists.
+
+References:
+  - https://www.macoratti.net/alg_pis.htm.
+
+Args:
+  * pis (str): PIS number as a string with the proper length.
+
+Returns:
+  * bool: True if the PIS is valid, False otherwise.
+
+Example:
 
 ```python
 from brutils import is_valid_pis
-
->>> is_valid_pis("12038619494")
+>>> is_valid_pis("82178537464")
+False
+>>> is_valid_pis("12082043519")
 True
->>> is_valid_pis("11111111111")
-False
->>> is_valid_pis("123456")
-False
-```
-
-### generate_pis
-
-Generates a valid random PIS/PASEP number.
-
-```python
-from brutils import generate_pis
-
->>> generate_pis()
-'12038619494'
->>> generate_pis()
-'57817700092'
->>> generate_pis()
-'49850211630'
-```
-
-### remove_symbols_pis
-
-Removes the formatting symbols ("-" and ".") from a PIS/PASEP number. It doesn't remove other symbols on purpose.
-
-```python
-from brutils import remove_symbols_pis
-
->>> remove_symbols_pis('170.33259.50-4')
-'17033259504'
->>> remove_symbols_pis('/._')
-'/_'
 ```
 
 ### format_pis
 
-Format the PIS number. Returns None if the PIS is invalid.
+Formats a valid PIS (Programa de Integração Social) string with symbols and adds standard formatting symbols for display.
+
+Args:
+  * pis (str): A valid string of PIS containing only numbers.
+
+Returns:
+  * str: A formatted PIS string with standard visual aid symbols or None if the input is invalid.
+
+Example:
 
 ```python
->>> from brutils import format_pis
->>> format_pis('12038619494')
-'120.38619.49-4'
+from brutils import format_pis
+>>> format_pis("17033259504")
+'170.33259.50-4'
+>>> format_pis("12013128292")
+'120.13128.29-2'
+```
+
+### remove_symbols_pis
+
+This function takes a string of PIS (Programa de Integração Social) with formatting symbols and returns a clean version without certain symbols. It intentionally removes only the symbols "-" and ".", leaving other symbols untouched.
+
+Args:
+  * pis (str): A string of PIS that may contain formatting symbols.
+
+Returns:
+  * str: A clean string of PIS without formatting symbols.
+
+Example:
+
+```python
+from brutils import remove_symbols_pis
+>>> remove_symbols_pis('170.33259.50-4')
+'17033259504'
+>>> remove_symbols_pis("123.456.789-09")
+'12345678909'
+>>> remove_symbols_pis('/._')
+'/_'
+```
+
+### generate_pis
+
+Generates a string of digits containing a random valid Brazilian PIS number.
+
+Returns:
+  * str: A randomly generated valid PIS number as a string.
+
+Example:
+
+```python
+from brutils import generate_pis
+>>> generate_pis()
+'61352489741'
+>>> generate_pis()
+'73453349671'
 ```
 
 ## Legal Process
+
+## is_valid_legal_process
+
+Check if a legal process ID is valid.
+
+This function does not verify if the legal process ID is a real legal
+process ID; it only validates the format of the string.
+
+Args:
+  * legal_process_id (str): A digit-only string representing the legal
+                            process ID.
+
+Returns:
+  * bool: True if the legal process ID is valid, False otherwise.
+
+Example:
+
+```python
+>>> from brutils import is_valid_legal_process
+>>> is_valid_legal_process('10188748220234018200')
+True
+>>> is_valid_legal_process('45532346920234025107')
+True
+>>> is_valid_legal_process('00000000000000000000')
+False
+>>> is_valid_legal_process('455323423QQWEQWSsasd&*(()')
+False
+>>>
+```
 
 ### format_legal_process
 
@@ -798,7 +841,6 @@ Example:
 
 ```python
 from brutils import remove_symbols_legal_process
-
 >>> remove_symbols_legal_process("6439067-89.2023.4.04.5902")
 "64390678920234045902"
 >>> remove_symbols_legal_process("4976023-82.2012.7.00.2263")
@@ -819,7 +861,7 @@ Args:
                  (default is random).
 
 Returns:
-    str: A randomly generated legal process ID.
+  * str: A randomly generated legal process ID.
          None if one of the arguments is invalid.
 
 Example:
@@ -834,35 +876,6 @@ Example:
 "37573041520235090313"
 >>> generate_legal_process(year=2024, orgao=4)
 "33158248820244017105"
-```
-
-## is_valid_legal_process
-
-Check if a legal process ID is valid.
-
-This function does not verify if the legal process ID is a real legal
-process ID; it only validates the format of the string.
-
-Args:
-  * legal_process_id (str): A digit-only string representing the legal
-                            process ID.
-
-Returns:
-  * bool: True if the legal process ID is valid, False otherwise.
-
-Example:
-
-```python
->>> from brutils import is_valid_legal_process
->>> is_valid_legal_process('10188748220234018200')
-True
->>> is_valid_legal_process('45532346920234025107')
-True
->>> is_valid_legal_process('00000000000000000000')
-False
->>> is_valid_legal_process('455323423QQWEQWSsasd&*(()')
-False
->>>
 ```
 
 ## Voter ID

--- a/brutils/__init__.py
+++ b/brutils/__init__.py
@@ -63,6 +63,8 @@ from brutils.license_plate import (
 )
 from brutils.phone import (
     format_phone,
+    remove_international_dialing_code,
+    remove_symbols_phone,
 )
 from brutils.phone import (
     generate as generate_phone,

--- a/brutils/legal_process.py
+++ b/brutils/legal_process.py
@@ -7,6 +7,29 @@ from random import randint
 ############
 
 
+def remove_symbols(legal_process: str):  # type: (str) -> str
+    """
+    Removes specific symbols from a given legal process.
+
+    This function takes a legal process as input and removes all occurrences
+    of the '.' and '-' characters from it.
+
+    Args:
+        legal_process (str): A legal process containing symbols to be removed.
+
+    Returns:
+        str: The legal process string with the specified symbols removed.
+
+    Example:
+        >>> remove_symbols("123.45-678.901.234-56.7890")
+        '12345678901234567890'
+        >>> remove_symbols("9876543-21.0987.6.54.3210")
+        '98765432109876543210'
+    """
+
+    return legal_process.replace(".", "").replace("-", "")
+
+
 def format_legal_process(legal_process_id):  # type: (str) -> (str)
     """
     Format a legal process ID into a standard format.
@@ -34,29 +57,6 @@ def format_legal_process(legal_process_id):  # type: (str) -> (str)
         return re.sub(capture_fields, include_chars, legal_process_id)
 
     return None
-
-
-def remove_symbols(legal_process: str):  # type: (str) -> str
-    """
-    Removes specific symbols from a given legal process.
-
-    This function takes a legal process as input and removes all occurrences
-    of the '.' and '-' characters from it.
-
-    Args:
-        legal_process (str): A legal process containing symbols to be removed.
-
-    Returns:
-        str: The legal process string with the specified symbols removed.
-
-    Example:
-        >>> remove_symbols("123.45-678.901.234-56.7890")
-        '12345678901234567890'
-        >>> remove_symbols("9876543-21.0987.6.54.3210")
-        '98765432109876543210'
-    """
-
-    return legal_process.replace(".", "").replace("-", "")
 
 
 # OPERATIONS

--- a/brutils/license_plate.py
+++ b/brutils/license_plate.py
@@ -189,6 +189,13 @@ def generate(format="LLLNLNN"):  # type: (str) -> str | None
 def _is_valid_old_format(license_plate: str) -> bool:
     """
     Checks whether a string matches the old format of Brazilian license plate.
+    Args:
+        license_plate (str): The desired format for the license plate.
+                                pattern:'LLLNNNN'
+
+    Returns:
+        bool: True if the plate number is valid. False otherwise.
+
     """
     pattern = re.compile(r"^[A-Za-z]{3}[0-9]{4}$")
     return (
@@ -199,9 +206,14 @@ def _is_valid_old_format(license_plate: str) -> bool:
 
 def _is_valid_mercosul(license_plate: str) -> bool:
     """
-    Returns whether or not the provided license_plate is valid according to the
-    Mercosul pattern (LLLNLNN). Input should be a digit string of proper
-    length. Ex: ABC4E67
+    Checks whether a string matches the old format of Brazilian license plate.
+    Args:
+        license_plate (str): The desired format for the license plate.
+                            pattern:'LLLNLNN'
+
+    Returns:
+        bool: True if the plate number is valid. False otherwise.
+
     """
     if not isinstance(license_plate, str):
         return False

--- a/brutils/phone.py
+++ b/brutils/phone.py
@@ -20,7 +20,6 @@ def format_phone(phone):  # type: (str) -> str
     >>> format_phone("1635014415")
     '(16)3501-4415'
     >>> format_phone("333333")
-    >>>
     """
     if not is_valid(phone):
         return None
@@ -63,7 +62,14 @@ def remove_symbols_phone(phone_number):  # type: (str) -> str
     """
     Removes common symbols from a Brazilian phone number string.
 
+    Args:
+        phone_number (str): The phone number to remove symbols.
+                            Can include two digits DDD.
+
+    Returns:
+        str: A new string with the specified symbols removed.
     """
+
     cleaned_phone = (
         phone_number.replace("(", "")
         .replace(")", "")
@@ -90,7 +96,7 @@ def generate(type=None):  # type: (str) -> str
         "2234451215"
         >>> generate("mobile")
         "1899115895"
-        >>> generate()"landline")
+        >>> generate("landline")
         "5535317900"
     """
 
@@ -104,7 +110,7 @@ def generate(type=None):  # type: (str) -> str
     return choice(generate_functions)()
 
 
-def remove_international_code_phone(phone_number):  # type: (str) -> str
+def remove_international_dialing_code(phone_number):  # type: (str) -> str
     """
     Function responsible for remove a international code phone
 
@@ -115,11 +121,12 @@ def remove_international_code_phone(phone_number):  # type: (str) -> str
         str: The phone number without international code
             or the same phone number.
 
-    >>> remove_international_code_phone("5511994029275")
+    Example:
+    >>> remove_international_dialing_code("5511994029275")
     '11994029275'
-    >>> remove_international_code_phone("1635014415")
+    >>> remove_international_dialing_code("1635014415")
     '1635014415'
-    >>> remove_international_code_phone("+5511994029275")
+    >>> remove_international_dialing_code("+5511994029275")
     '+11994029275'
     """
 

--- a/brutils/pis.py
+++ b/brutils/pis.py
@@ -5,12 +5,55 @@ WEIGHTS = [3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
 # FORMATTING
 ############
 
-# TODO: remover este comentário e implementar a formatação do PIS.
-
 
 def remove_symbols(pis: str) -> str:
-    """Filters out PIS formatting symbols."""
+    """
+    Remove formatting symbols from a PIS.
+
+    This function takes a PIS (Programa de Integração Social) string with
+    formatting symbols and returns a cleaned version with no symbols.
+
+    Args:
+        pis (str): A PIS string that may contain formatting symbols.
+
+    Returns:
+        str: A cleaned PIS string with no formatting symbols.
+
+    Example:
+        >>> remove_symbols("123.456.789-09")
+        '12345678909'
+        >>> remove_symbols("98765432100")
+        '98765432100'
+    """
     return pis.replace(".", "").replace("-", "")
+
+
+def format_pis(pis: str) -> str:
+    """
+    Format a valid PIS (Programa de Integração Social) string with
+    standard visual aid symbols.
+
+    This function takes a valid numbers-only PIS string as input
+    and adds standard formatting visual aid symbols for display.
+
+    Args:
+        pis (str): A valid numbers-only PIS string.
+
+    Returns:
+        str: A formatted PIS string with standard visual aid symbols
+        or None if the input is invalid.
+
+    Example:
+        >>> format_pis("12345678909")
+        '123.45678.90-9'
+        >>> format_pis("98765432100")
+        '987.65432.10-0'
+    """
+
+    if not is_valid(pis):
+        return None
+
+    return "{}.{}.{}-{}".format(pis[:3], pis[3:8], pis[8:10], pis[10:11])
 
 
 # OPERATIONS
@@ -19,18 +62,24 @@ def remove_symbols(pis: str) -> str:
 
 def validate(pis: str) -> bool:
     """
-    Validate a Brazilian PIS number.
+     Validate a Brazilian PIS number.
 
-    The PIS is valid if:
-    - It has 11 digits
-    - All characters are digits
-    - It passes the weight calculation check
+     The PIS is valid if:
+     - It has 11 digits
+     - All characters are digits
+     - It passes the weight calculation check
 
-    Args:
-        pis[str]: PIS number as a string.
+     Args:
+         pis(str): PIS number as a string.
 
-    Returns:
-        value[bool]: True if PIS is valid, False otherwise.
+     Returns:
+         bool: True if PIS is valid, False otherwise.
+
+    Example:
+         >>> validate("82178537464")
+         True
+         >>> validate("55550207753")
+         True
     """
     if len(pis) != 11 or not pis.isdigit():
         return False
@@ -41,26 +90,43 @@ def validate(pis: str) -> bool:
 def is_valid(pis: str) -> bool:
     """
     Returns whether or not the verifying checksum digit of the
-    given `pis` match its base number.
+    given `PIS` match its base number.
 
     Args:
-        pis[str]: PIS number as a string of proper length.
+        pis (str): PIS number as a string of proper length.
 
     Returns:
-        value[bool]: True if PIS is valid, False otherwise.
+        bool: True if PIS is valid, False otherwise.
+
+    Example:
+    >>> is_valid_pis("82178537464")
+    True
+    >>> is_valid_pis("55550207753")
+    True
+
     """
     return isinstance(pis, str) and validate(pis)
 
 
 def generate() -> str:
     """
-    Generates a random valid Brazilian PIS number.
+    Generate a random valid Brazilian PIS number.
+
+    This function generates a random PIS number with the following characteristics:
+    - It has 11 digits
+    - It passes the weight calculation check
 
     Args:
         None
 
     Returns:
-        value[str]: PIS number as a string.
+        str: A randomly generated valid PIS number as a string.
+
+    Example:
+        >>> generate()
+        '12345678909'
+        >>> generate()
+        '98765432100'
     """
     base = str(randint(0, 9999999999)).zfill(10)
 
@@ -69,30 +135,16 @@ def generate() -> str:
 
 def _checksum(base_pis: str) -> int:
     """
-    Calculates the checksum digit of the given `base_pis` string.
+    Calculate the checksum digit of the given `base_pis` string.
 
     Args:
-        base_pis [str]: 10 first digits of PIS number as a string.
+        base_pis (str): The first 10 digits of a PIS number as a string.
 
     Returns:
-        value [int]: Checksum digit.
+        int: The checksum digit.
     """
     pis_digits = list(map(int, base_pis))
     pis_sum = sum(digit * weight for digit, weight in zip(pis_digits, WEIGHTS))
     check_digit = 11 - (pis_sum % 11)
 
     return 0 if check_digit in [10, 11] else check_digit
-
-
-def format_pis(pis: str) -> str:
-    """
-    Format an adequately formatted numbers-only PIS string,
-    Returns a PIS formatted with standard visual aid symbols.
-    Returns :
-        value [str]: PIS formatted
-    """
-
-    if not is_valid(pis):
-        return None
-
-    return "{}.{}.{}-{}".format(pis[:3], pis[3:8], pis[8:10], pis[10:11])

--- a/tests/test_phone.py
+++ b/tests/test_phone.py
@@ -7,7 +7,7 @@ from brutils.phone import (
     format_phone,
     generate,
     is_valid,
-    remove_international_code_phone,
+    remove_international_dialing_code,
     remove_symbols_phone,
 )
 
@@ -257,32 +257,32 @@ class TestPhone(TestCase):
                     _is_valid_landline(landline_phone_generated), True
                 )
 
-    def test_remove_international_code_phone(self):
+    def test_remove_international_dialing_code(self):
         # When the phone number does not have the international code,
         # return the same phone number
         self.assertEqual(
-            remove_international_code_phone("21994029275"), "21994029275"
+            remove_international_dialing_code("21994029275"), "21994029275"
         )
         self.assertEqual(
-            remove_international_code_phone("55994024478"), "55994024478"
+            remove_international_dialing_code("55994024478"), "55994024478"
         )
         self.assertEqual(
-            remove_international_code_phone("994024478"), "994024478"
+            remove_international_dialing_code("994024478"), "994024478"
         )
 
         # When the phone number has the international code,
         # return phone number without international code
         self.assertEqual(
-            remove_international_code_phone("5521994029275"), "21994029275"
+            remove_international_dialing_code("5521994029275"), "21994029275"
         )
         self.assertEqual(
-            remove_international_code_phone("+5521994029275"), "+21994029275"
+            remove_international_dialing_code("+5521994029275"), "+21994029275"
         )
         self.assertEqual(
-            remove_international_code_phone("+5555994029275"), "+55994029275"
+            remove_international_dialing_code("+5555994029275"), "+55994029275"
         )
         self.assertEqual(
-            remove_international_code_phone("5511994029275"), "11994029275"
+            remove_international_dialing_code("5511994029275"), "11994029275"
         )
 
 


### PR DESCRIPTION
## Descrição
Ajustando as Docstrings restantes e aproveitei para padronizar também os arquivos de `README.md` e `README_en.md`

## Mudanças Propostas
<!--- Liste as principais alterações ou melhorias que estão sendo propostas neste Pull Request.
Padrão do README:
- is_valid(...);
- format(...);
- remove_symbols(...);
- generate(...);
- se houver outras funções, ficam abaixo por ordem alfabética.


## Checklist de Revisão
<!--- Marque as caixas que se aplicam. Você pode deixar caixas desmarcadas se elas não se aplicarem.-->

- [x] Eu li o [Contributing.md](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md)
- [x] Os testes foram adicionados ou atualizados para refletir as mudanças (se aplicável).
- [x] Foi adicionada uma entrada no changelog / Meu PR não necessita de uma nova entrada no changelog.
- [x] A [documentação](https://github.com/brazilian-utils/brutils-python/blob/main/README.md) em português foi atualizada ou criada, se necessário.
- [x] Se feita a documentação, a atualização do [arquivo em inglês](https://github.com/brazilian-utils/brutils-python/blob/main/README_EN.md). <!---Permitido uso de Google Tradutor/ChatGPT. -->
- [x] Eu documentei as minhas mudanças no código, adicionando docstrings e comentários. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#8-fa%C3%A7a-as-suas-altera%C3%A7%C3%B5es)
- [x] O código segue as diretrizes de estilo e padrões de codificação do projeto.
- [x] Todos os testes passam. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#testes)
- [x] O Pull Request foi testado localmente. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#7-execute-o-brutils-localmente)
- [ ] Não há conflitos de mesclagem.

## Comentários Adicionais (opcional)
No arquivo `phone.py` (e subsequentes) mudei também o nome da função  `remove_international_code_phone` para `remove_international_dialing_code` pois achei que soaria melhor. Fiquei entre esse e remove_international_coutry_code. 

P.S.: nesse mesmo momento descobri que esta função e mais uma não estavam no arquivo `__init__.py`, portanto não estavam funcionando como o esperado e ajustei.

## Issue Relacionada
<!---Todos os PRs devem ter uma issue relacionada. Dessa forma, podemos garantir que ninguém perca tempo trabalhando em algo que não precisa ser feito. -->

Closes #257 
