### PR TITLE
Implementar função para remover símbolos específicos de uma string de CPF

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ Argumentos:
 
 Retorna:
 
-- str: Uma nova string com os símbolos especificados removidos.
+- str: Uma nova string com os símbolos especificados removidos. Caso o CPF
+fornecido não seja válido, retornará None
 
 Exemplo:
 
@@ -162,6 +163,14 @@ Exemplo:
 >>> from brutils import remove_symbols_cpf
 >>> remove_symbols_cpf('000.111.222-33')
 '00011122233'
+>>> remove_symbols_cpf('000.111.222-3')
+None
+>>> remove_symbols_cpf('000.111.222-333')
+None
+>>> remove_symbols_cpf('')
+None
+>>> remove_symbols_cpf(123)
+None
 ```
 
 ### generate_cpf

--- a/README_EN.md
+++ b/README_EN.md
@@ -151,7 +151,8 @@ the '.', '-' characters from it.
 
 Args:
 
-- cpf (str): The CPF string containing symbols to be removed.
+- cpf (str): The CPF string containing symbols to be removed. If the provided
+CPF is invalid, it'll return None.
 
 Returns:
 
@@ -163,6 +164,14 @@ Example:
 >>> from brutils import remove_symbols_cpf
 >>> remove_symbols_cpf('000.111.222-33')
 '00011122233'
+>>> remove_symbols_cpf('000.111.222-3')
+None
+>>> remove_symbols_cpf('000.111.222-333')
+None
+>>> remove_symbols_cpf('')
+None
+>>> remove_symbols_cpf(123)
+None
 ```
 
 ### generate_cpf

--- a/brutils/__init__.py
+++ b/brutils/__init__.py
@@ -31,15 +31,14 @@ from brutils.cnpj import (
 # CPF Imports
 from brutils.cpf import (
     format_cpf,
+    remove_symbols,
+    remove_symbols_cpf,
 )
 from brutils.cpf import (
     generate as generate_cpf,
 )
 from brutils.cpf import (
     is_valid as is_valid_cpf,
-)
-from brutils.cpf import (
-    remove_symbols as remove_symbols_cpf,
 )
 
 # Email Import

--- a/brutils/__init__.py
+++ b/brutils/__init__.py
@@ -31,14 +31,18 @@ from brutils.cnpj import (
 # CPF Imports
 from brutils.cpf import (
     format_cpf,
-    remove_symbols,
-    remove_symbols_cpf,
 )
 from brutils.cpf import (
     generate as generate_cpf,
 )
 from brutils.cpf import (
     is_valid as is_valid_cpf,
+)
+from brutils.cpf import (
+    remove_symbols as remove_symbols_cpf,
+)
+from brutils.cpf import (
+    remove_symbols_cpf as remove_symbols_from_cpf,
 )
 
 # Email Import
@@ -140,6 +144,7 @@ __all__ = [
     "generate_cpf",
     "is_valid_cpf",
     "remove_symbols_cpf",
+    "remove_symbols_from_cpf",
     # Email
     "is_valid_email",
     # Legal Process

--- a/brutils/cpf.py
+++ b/brutils/cpf.py
@@ -272,18 +272,12 @@ def remove_symbols_cpf(cpf: str) -> str:
         None
     """
 
+    result = None
     cpf_no_symbols = ""
-    if cpf == "":
-        return None
-    elif not isinstance(cpf, str):
-        return None
-    else:
-        for character in cpf:
-            if character not in ".-":
-                cpf_no_symbols += character
-        if len(cpf_no_symbols) < 10:
-            return None
-        elif len(cpf_no_symbols) > 11:
-            return None
-        else:
-            return cpf_no_symbols
+    if isinstance(cpf, str) and cpf != "":
+        cpf_no_symbols = "".join([char for char in cpf if char not in ".-"])
+
+    if len(cpf_no_symbols) == 11:
+        result = cpf_no_symbols
+
+    return result

--- a/brutils/cpf.py
+++ b/brutils/cpf.py
@@ -271,13 +271,13 @@ def remove_symbols_cpf(cpf: str) -> str:
         >>> remove_symbols_cpf('000.111.222-333')
         None
     """
+    CPF_LENGHT = 11
 
-    result = None
-    cpf_no_symbols = ""
+    if not cpf:
+        return None
+
     if isinstance(cpf, str) and cpf != "":
-        cpf_no_symbols = "".join([char for char in cpf if char not in ".-"])
+        cpf_no_symbols = "".join([char for char in cpf if char.isalnum()])
 
-    if len(cpf_no_symbols) == 11:
-        result = cpf_no_symbols
-
-    return result
+        if len(cpf_no_symbols) == CPF_LENGHT:
+            return cpf_no_symbols

--- a/brutils/cpf.py
+++ b/brutils/cpf.py
@@ -243,3 +243,47 @@ def _checksum(basenum):  # type: (str) -> str
     verifying_digits += str(_hashdigit(basenum + verifying_digits, 11))
 
     return verifying_digits
+
+
+def remove_symbols_cpf(cpf: str) -> str:
+    """
+    Compute the checksum digits for a given CPF base number.
+
+    This function removes the symbols dot and dash (`.` and `-`) from a CPF.
+
+    Args:
+        basenum (str): A formatted CPF string with standard visual aid symbols or None
+        if the input is invalid.
+
+    Returns:
+        str: A numbers-only CPF string. If it's not a valid number or format, it'll return None.
+
+    Example:
+        >>> from brutils import remove_symbols_cpf
+        >>> remove_symbols_cpf('000.111.222-33')
+        '00011122233'
+        >>> remove_symbols_cpf('')
+        None
+        >>>     remove_symbols_cpf(123)
+        None
+        >>> remove_symbols_cpf('000.111.222')
+        None
+        >>> remove_symbols_cpf('000.111.222-333')
+        None
+    """
+
+    cpf_no_symbols = ""
+    if cpf == "":
+        return None
+    elif not isinstance(cpf, str):
+        return None
+    else:
+        for character in cpf:
+            if character not in ".-":
+                cpf_no_symbols += character
+        if len(cpf_no_symbols) < 10:
+            return None
+        elif len(cpf_no_symbols) > 11:
+            return None
+        else:
+            return cpf_no_symbols

--- a/tests/test_cpf.py
+++ b/tests/test_cpf.py
@@ -9,6 +9,7 @@ from brutils.cpf import (
     generate,
     is_valid,
     remove_symbols,
+    remove_symbols_cpf,
     sieve,
     validate,
 )
@@ -107,6 +108,18 @@ class TestIsValidToFormat(TestCase):
 
         # When cpf isn't valid, returns None
         self.assertIsNone(format_cpf("11144477735"))
+
+
+@patch("brutils.cpf.remove_symbols_cpf")
+class TestRemoveSymbolsCPF(TestCase):
+    def test_remove_symbols_cpf_positive(self, mock_remove_symbols_cpf):
+        self.assertEqual(remove_symbols_cpf("123.456.789-10"), "12345678910")
+
+    def test_remove_symbols_cpf_negative_int(self, mock_remove_symbols_cpf):
+        self.assertIsNone(remove_symbols_cpf(123456789))
+
+    def test_remove_symbols_cpf_negative_empy(self, mock_remove_symbols_cpf):
+        self.assertIsNone(remove_symbols_cpf(""))
 
 
 if __name__ == "__main__":

--- a/tests/test_cpf.py
+++ b/tests/test_cpf.py
@@ -121,6 +121,12 @@ class TestRemoveSymbolsCPF(TestCase):
     def test_remove_symbols_cpf_negative_empy(self, mock_remove_symbols_cpf):
         self.assertIsNone(remove_symbols_cpf(""))
 
+    def test_remove_symbols_cpf_negative_longer(self, mock_remove_symbols_cpf):
+        self.assertIsNone(remove_symbols_cpf("111.222.333-444"))
+
+    def test_remove_symbols_cpf_negative_shorter(self, mock_remove_symbols_cpf):
+        self.assertIsNone(remove_symbols_cpf("111.222.333"))
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Descrição
Implementada a função `remove_symbols_cpf`, que irá remover os símbolos `.` e `-` do CPF fornecido. Em caso de envio de string vazia, ou um inteiro, ou um CPF faltando números ou com números a mais, irá retornar None. Também implementada a Docstring e a doctest, conforme solicitado na issue #437. Adicionado os testes unitários referente a essa função, testando positivamente para remover os symbols, negativo para cpf inválidos ou não formatados.

## Checklist de Revisão
<!--- Marque as caixas que se aplicam. Você pode deixar caixas desmarcadas se elas não se aplicarem.-->

- [x] Eu li o [Contributing.md](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md)
- [x] Os testes foram adicionados ou atualizados para refletir as mudanças (se aplicável).
- [x] Foi adicionada uma entrada no changelog / Meu PR não necessita de uma nova entrada no changelog.
- [x] A [documentação](https://github.com/brazilian-utils/brutils-python/blob/main/README.md) em português foi atualizada ou criada, se necessário.
- [x] Se feita a documentação, a atualização do [arquivo em inglês](https://github.com/brazilian-utils/brutils-python/blob/main/README_EN.md). <!---Permitido uso de Google Tradutor/ChatGPT. -->
- [x] Eu documentei as minhas mudanças no código, adicionando docstrings e comentários. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#8-fa%C3%A7a-as-suas-altera%C3%A7%C3%B5es)
- [x] O código segue as diretrizes de estilo e padrões de codificação do projeto.
- [x] Todos os testes passam. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#testes)
- [ ] O Pull Request foi testado localmente. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#7-execute-o-brutils-localmente)
- [ ] Não há conflitos de mesclagem.

## Issue Relacionada
<!---Todos os PRs devem ter uma issue relacionada. Dessa forma, podemos garantir que ninguém perca tempo trabalhando em algo que não precisa ser feito. -->

Closes #437 
