### PR TITLE
feat: adicionar automação para gerenciar PRs inativos com GitHub Actions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+name: 'Mark stale pull requests'
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 60
+          days-before-close: 7
+          stale-pr-label: "Stale"
+          stale-pr-message: >
+            [PT-BR] Este PR está inativo há muito tempo. Caso não seja atualizado, será fechado em 7 dias.  
+            [EN] This PR has been inactive for a long time. If no updates are made, it will be closed in 7 days.
+          close-pr-message: >
+            [PT-BR] Este PR foi fechado devido à inatividade. Caso ainda seja relevante, por favor, reabra ou crie um novo PR.  
+            [EN] This PR has been closed due to inactivity. If it is still relevant, please reopen or create a new PR.
+          exempt-issue-labels: "keep-open"
+          operations-per-run: 30
+          remove-stale-when-updated: true


### PR DESCRIPTION
## Descrição  
Este Pull Request adiciona uma automação para gerenciar PRs inativos no repositório utilizando a ação **Stale** do GitHub Actions. A automação ajuda a manter o repositório organizado, lidando automaticamente com PRs que estão inativos por períodos prolongados.  

## Mudanças Propostas  
- Criação do arquivo `.github/workflows/stale.yml` para configurar o workflow.  
- Configuração para marcar PRs como "Stale" após 60 dias de inatividade.  
- Configuração para fechar PRs 7 dias após serem marcados como "Stale", caso não haja atualizações.  
- Adição de mensagens personalizadas para notificar colaboradores sobre PRs inativos e fechados.  

## Checklist de Revisão  
- [x] Eu li o [[Contributing.md](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md)](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md).  
- [x] Os testes foram adicionados ou atualizados para refletir as mudanças (se aplicável).  
- [x] Foi adicionada uma entrada no changelog / Meu PR não necessita de uma nova entrada no changelog.  
- [x] A [[documentação](https://github.com/brazilian-utils/brutils-python/blob/main/README.md)](https://github.com/brazilian-utils/brutils-python/blob/main/README.md) em português foi atualizada ou criada, se necessário.  
- [x] Se feita a documentação, a atualização do [[arquivo em inglês](https://github.com/brazilian-utils/brutils-python/blob/main/README_EN.md)](https://github.com/brazilian-utils/brutils-python/blob/main/README_EN.md).  
- [x] Eu documentei as minhas mudanças no código, adicionando docstrings e comentários.  
- [x] O código segue as diretrizes de estilo e padrões de codificação do projeto.  
- [x] Todos os testes passam.  
- [x] O Pull Request foi testado localmente.  
- [x] Não há conflitos de mesclagem.  

## Comentários Adicionais  
Esta automação pode ser facilmente ajustada no futuro para alterar os prazos ou mensagens caso necessário.  

- Evidência de êxito no teste:
![Screenshot 2025-01-23 at 06 06 15](https://github.com/user-attachments/assets/dc67167c-b1a2-4283-83c1-2d6cae0899e0)

## Issue Relacionada  
Closes #467 