### PR TITLE
Adiciona testes MC/DC para o método get_address_from_cep e cobre linha não testada apontada na issue #466

### DIFF
--- a/tests/test_cep.py
+++ b/tests/test_cep.py
@@ -171,7 +171,6 @@ class TestCEPAPICalls(TestCase):
 
 @patch("brutils.cep.urlopen")
 class TestGetAddressFromCEP_MC_DC(TestCase):
-
     def test_ct1_cep_invalido_com_excecao(self, mock_urlopen):
         """CT1: cep inválido e raise_exceptions=True → lança InvalidCEP"""
         with self.assertRaises(InvalidCEP):
@@ -189,13 +188,13 @@ class TestGetAddressFromCEP_MC_DC(TestCase):
         # A função get_address_from_cep faz dois loads() no mesmo JSON
         mock_loads.side_effect = [
             {"cep": "01001-000"},  # Primeiro loads para verificar "erro"
-            {"cep": "01001-000"}   # Segundo loads para retornar Address
+            {"cep": "01001-000"},  # Segundo loads para retornar Address
         ]
 
         # Simula a resposta da API ViaCEP
         mock_response = MagicMock()
         mock_response.read.return_value = b'{"cep": "01001-000"}'
-        
+
         # Corrige o mock para suportar o contexto "with urlopen(...) as f"
         mock_urlopen.return_value.__enter__.return_value = mock_response
 
@@ -206,7 +205,6 @@ class TestGetAddressFromCEP_MC_DC(TestCase):
         self.assertIsInstance(result, dict)
         self.assertEqual(result.get("cep"), "01001-000")
 
-
     def test_ct4_erro_na_api_com_excecao(self, mock_urlopen):
         """CT4: cep válido mas inexistente + raise_exceptions=True → lança CEPNotFound"""
         mock_response = MagicMock()
@@ -216,7 +214,6 @@ class TestGetAddressFromCEP_MC_DC(TestCase):
         with self.assertRaises(CEPNotFound):
             get_address_from_cep("99999999", raise_exceptions=True)
 
-
     def test_ct5_erro_na_api_sem_excecao(self, mock_urlopen):
         """CT5: cep válido mas inexistente + raise_exceptions=False → retorna None"""
         mock_response = mock_urlopen.return_value
@@ -225,7 +222,9 @@ class TestGetAddressFromCEP_MC_DC(TestCase):
         result = get_address_from_cep("99999999", raise_exceptions=False)
         self.assertIsNone(result)
 
-    def test_ct6_viacep_responde_com_erro_e_raise_exceptions_true(self, mock_urlopen):
+    def test_ct6_viacep_responde_com_erro_e_raise_exceptions_true(
+        self, mock_urlopen
+    ):
         """
         CT6: cobre a linha 172 e a decisão CD2 (data.get("erro", True))
         """

--- a/tests/test_cep.py
+++ b/tests/test_cep.py
@@ -169,5 +169,73 @@ class TestCEPAPICalls(TestCase):
             )
 
 
+@patch("brutils.cep.urlopen")
+class TestGetAddressFromCEP_MC_DC(TestCase):
+
+    def test_ct1_cep_invalido_com_excecao(self, mock_urlopen):
+        """CT1: cep inválido e raise_exceptions=True → lança InvalidCEP"""
+        with self.assertRaises(InvalidCEP):
+            get_address_from_cep("abcdefg", raise_exceptions=True)
+
+    def test_ct2_cep_invalido_sem_excecao(self, mock_urlopen):
+        """CT2: cep inválido e raise_exceptions=False → retorna None"""
+        result = get_address_from_cep("abcdefg", raise_exceptions=False)
+        self.assertIsNone(result)
+
+    @patch("brutils.cep.loads")
+    def test_ct3_cep_valido(self, mock_loads, mock_urlopen):
+        """CT3: cep válido → retorna dicionário com endereço"""
+
+        # A função get_address_from_cep faz dois loads() no mesmo JSON
+        mock_loads.side_effect = [
+            {"cep": "01001-000"},  # Primeiro loads para verificar "erro"
+            {"cep": "01001-000"}   # Segundo loads para retornar Address
+        ]
+
+        # Simula a resposta da API ViaCEP
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'{"cep": "01001-000"}'
+        
+        # Corrige o mock para suportar o contexto "with urlopen(...) as f"
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        # Executa a chamada
+        result = get_address_from_cep("01001000", raise_exceptions=False)
+
+        # Valida o resultado
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result.get("cep"), "01001-000")
+
+
+    def test_ct4_erro_na_api_com_excecao(self, mock_urlopen):
+        """CT4: cep válido mas inexistente + raise_exceptions=True → lança CEPNotFound"""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'{"erro": true}'
+        mock_urlopen.return_value = mock_response
+
+        with self.assertRaises(CEPNotFound):
+            get_address_from_cep("99999999", raise_exceptions=True)
+
+
+    def test_ct5_erro_na_api_sem_excecao(self, mock_urlopen):
+        """CT5: cep válido mas inexistente + raise_exceptions=False → retorna None"""
+        mock_response = mock_urlopen.return_value
+        mock_response.read.return_value = b'{"erro": true}'
+
+        result = get_address_from_cep("99999999", raise_exceptions=False)
+        self.assertIsNone(result)
+
+    def test_ct6_viacep_responde_com_erro_e_raise_exceptions_true(self, mock_urlopen):
+        """
+        CT6: cobre a linha 172 e a decisão CD2 (data.get("erro", True))
+        """
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'{"erro": true}'
+        mock_urlopen.return_value = mock_response
+
+        with self.assertRaises(CEPNotFound):
+            get_address_from_cep("01001000", raise_exceptions=True)
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Descrição
Este Pull Request implementa testes adicionais para o método `get_address_from_cep`, com foco na aplicação do critério MC/DC (Modified Condition/Decision Coverage). O objetivo é cobrir completamente todas as decisões e condições do método, incluindo a linha 172 do arquivo `cep.py`, anteriormente não coberta, conforme apontado na issue #466.

## Mudanças Propostas

- Adição de novos testes unitários no grupo `TestGetAddressFromCEP_MC_DC`, simulando:
  - CEP inválido com/sem exceção (CT1 e CT2)
  - CEP válido com resposta da API (CT3)
  - API respondendo com erro, com/sem exceção (CT4 e CT5)
  - API respondendo com `{"erro": true}` para cobrir a linha 172 (CT6)
- Correção no mock de `urlopen` e `loads` para simular corretamente o contexto da API ViaCEP.
- Cobertura aumentada de 97% para 98% no módulo `cep.py`.
- Cobertura total do projeto aumentada de 98% para 99%.
- Todos os testes passaram localmente com sucesso.

## Checklist de Revisão

- [x] Eu li o [Contributing.md](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md)
- [x] Os testes foram adicionados ou atualizados para refletir as mudanças (se aplicável).
- [x] Foi adicionada uma entrada no changelog / Meu PR não necessita de uma nova entrada no changelog.
- [ ] A [documentação](https://github.com/brazilian-utils/brutils-python/blob/main/README.md) em português foi atualizada ou criada, se necessário.
- [ ] Se feita a documentação, a atualização do [arquivo em inglês](https://github.com/brazilian-utils/brutils-python/blob/main/README_EN.md).
- [x] Eu documentei as minhas mudanças no código, adicionando docstrings e comentários. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#8-fa%C3%A7a-as-suas-altera%C3%A7%C3%B5es)
- [x] O código segue as diretrizes de estilo e padrões de codificação do projeto.
- [x] Todos os testes passam. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#testes)
- [x] O Pull Request foi testado localmente. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#7-execute-o-brutils-localmente)
- [x] Não há conflitos de mesclagem.

## Comentários Adicionais (opcional)
Os testes foram organizados para facilitar a rastreabilidade e podem servir de base para testes de MC/DC em outros métodos que contenham múltiplas condições compostas.

## Issue Relacionada
Closes #466

