### PR TITLE
523

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Utilitário `get_code_by_municipality_name` [#399](https://github.com/brazilian-utils/brutils-python/issues/399)
 - Utilitário `format_currency` [#426](https://github.com/brazilian-utils/brutils-python/issues/426)
 - Utilitário `convert_real_to_text` [#387](https://github.com/brazilian-utils/brutils-python/pull/525)
+- Utilitário `validate_tin_angola`. [#523](https://github.com/brazilian-utils/brutils-python/issues/523)
 
 ## [2.2.0] - 2024-09-12
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,33 @@ False
 - [Monetário](#monetário)
   - [format\_currency](#format_currency)
   - [convert\_real\_to\_text](#convert_real_to_text)
+- [TIN Angola](#tin-angola)
+
+## TIN Angola
+
+### validate_tin_angola
+
+Valida um TIN (Número de Identificação Fiscal) de Angola.
+
+**Argumentos**:
+
+- `tin` (str): sequência de 9 dígitos numéricos.  
+  - Primeiro dígito: `1`, `5`, `6` ou `8`.  
+  - Nono dígito: dígito verificador por módulo 11 com pesos `[9,8,7,6,5,4,3,2]`.
+
+**Retorna**:
+
+- `bool`: `True` se o TIN for válido, `False` caso contrário.
+
+**Exemplos**:
+
+```python
+>>> from brutils import validate_tin_angola
+>>> validate_tin_angola("123456782")
+True
+>>> validate_tin_angola("023456789")
+False
+```
 
 ## CPF
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -98,6 +98,33 @@ False
 - [Monetary](#monetary)
   - [format_currency](#format_currency)
   - [convert\_real\_to\_text](#convert_real_to_text)
+- [Angolan TIN](#angolan-tin)
+
+## Angolan TIN
+
+### validate_tin_angola
+
+Validates an Angolan Tax Identification Number (TIN).
+
+**Args**:
+
+- `tin` (str): a 9-digit numeric string.  
+  - The first digit must be one of `1`, `5`, `6`, or `8`.  
+  - The ninth digit is a check digit calculated using modulo 11 with weights `[9,8,7,6,5,4,3,2]`.
+
+**Returns**:
+
+- `bool`: `True` if the TIN is valid, otherwise `False`.
+
+**Examples**:
+
+```python
+>>> from brutils import validate_tin_angola
+>>> validate_tin_angola("123456782")
+True
+>>> validate_tin_angola("023456789")
+False
+```
 
 ## CPF
 

--- a/brutils/__init__.py
+++ b/brutils/__init__.py
@@ -75,6 +75,9 @@ from brutils.voter_id import format_voter_id
 from brutils.voter_id import generate as generate_voter_id
 from brutils.voter_id import is_valid as is_valid_voter_id
 
+# TIN imports
+from .tin import validate_tin_angola
+
 # Defining __all__ to expose the public methods
 __all__ = [
     # CEP
@@ -134,4 +137,6 @@ __all__ = [
     # Currency
     "format_currency",
     "convert_real_to_text",
+    # TIN
+    "validate_tin_angola",
 ]

--- a/brutils/tin.py
+++ b/brutils/tin.py
@@ -1,0 +1,27 @@
+def validate_tin_angola(tin: str) -> bool:
+    """
+    Valida um TIN (Número de Identificação Fiscal) de Angola.
+
+    Regras:
+    - 9 dígitos numéricos.
+    - Primeiro dígito em {1,5,6,8}.
+    - Dígito verificador (9º) calculado com módulo 11:
+      pesos = [9,8,7,6,5,4,3,2].
+    """
+    # 1) Formato básico
+    if not isinstance(tin, str) or not tin.isdigit() or len(tin) != 9:
+        return False
+
+    # 2) Primeiro dígito
+    if tin[0] not in {"1", "5", "6", "8"}:
+        return False
+
+    # 3) Cálculo do dígito verificador
+    weights = [9, 8, 7, 6, 5, 4, 3, 2]
+    soma = sum(int(d) * w for d, w in zip(tin[:8], weights))
+    resto = soma % 11
+
+    dv_calculado = 0 if resto in (0, 1) else 11 - resto
+    dv_informado = int(tin[8])
+
+    return dv_calculado == dv_informado

--- a/tests/test_tin_angola.py
+++ b/tests/test_tin_angola.py
@@ -1,0 +1,39 @@
+import unittest
+
+from brutils.tin import validate_tin_angola
+
+
+class TestTinAngola(unittest.TestCase):
+    def calculate_dv(self, base: str) -> str:
+        weights = [9, 8, 7, 6, 5, 4, 3, 2]
+        soma = sum(int(d) * w for d, w in zip(base, weights))
+        resto = soma % 11
+        dv = 0 if resto in (0, 1) else 11 - resto
+        return str(dv)
+
+    def test_valid_tins(self):
+        # pegamos sequências iniciais quaisquer com primeiro dígito válido
+        bases = ["12345678", "58641234"]
+        for base in bases:
+            tin = base + self.calculate_dv(base)
+            with self.subTest(tin=tin):
+                self.assertTrue(
+                    validate_tin_angola(tin), f"{tin} deveria ser válido"
+                )
+
+    def test_invalid_tins(self):
+        invalid = [
+            "023456789",  # primeiro dígito inválido
+            "123456780",  # DV incorreto (mesmo base do primeiro teste, mas forçamos 0)
+            "12345678",  # muito curto
+            "abcdefgh9",  # não numérico
+        ]
+        for tin in invalid:
+            with self.subTest(tin=tin):
+                self.assertFalse(
+                    validate_tin_angola(tin), f"{tin} deveria ser inválido"
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Descrição
Este Pull Request implementa suporte à validação de TIN (Número de Identificação Fiscal) de Angola, incluindo:
- Função `validate_tin_angola` em `brutils/tin.py`
- Verificação de formato, primeiro dígito (1,5,6,8) e dígito verificador (módulo 11)
- Exposição da função em `brutils/__init__.py` e atualização de `__all__`
- Testes unitários em `tests/test_tin_angola.py` gerando dinamicamente o dígito verificador
- Atualização do `CHANGELOG.md` (seção Unreleased → Added)
- Documentação atualizada em `README.md` (pt) e `README_EN.md` (en)

## Mudanças Propostas
- **Código**  
  - `brutils/tin.py`: nova função `validate_tin_angola`  
  - `brutils/__init__.py`: import e inclusão em `__all__`  
- **Testes**  
  - `tests/test_tin_angola.py`: casos positivos e negativos seguindo TDD  
- **Documentação**  
  - `README.md`: adiciona seção “TIN Angola” em Utilitários  
  - `README_EN.md`: adiciona seção “Angolan TIN” em Utilities  
- **Changelog**  
  - `CHANGELOG.md` (Unreleased → Added): registro da issue #523  

## Checklist de Revisão
<!--- Marque as caixas que se aplicam. Você pode deixar caixas desmarcadas se elas não se aplicarem.-->

- [x] Eu li o [Contributing.md](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md)
- [x] Os testes foram adicionados ou atualizados para refletir as mudanças (se aplicável).
- [x] Foi adicionada uma entrada no changelog / Meu PR não necessita de uma nova entrada no changelog.
- [x] A [documentação](https://github.com/brazilian-utils/brutils-python/blob/main/README.md) em português foi atualizada ou criada, se necessário.
- [x] Se feita a documentação, a atualização do [arquivo em inglês](https://github.com/brazilian-utils/brutils-python/blob/main/README_EN.md). <!---Permitido uso de Google Tradutor/ChatGPT. -->
- [x] Eu documentei as minhas mudanças no código, adicionando docstrings e comentários. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#8-fa%C3%A7a-as-suas-altera%C3%A7%C3%B5es)
- [x] O código segue as diretrizes de estilo e padrões de codificação do projeto.
- [x] Todos os testes passam. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#testes)
- [x] O Pull Request foi testado localmente. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#7-execute-o-brutils-localmente)
- [x] Não há conflitos de mesclagem.

## Comentários Adicionais (opcional)
- Feedback sobre exemplos de TIN reais e possíveis ajustes de peso são bem-vindos!

## Issue Relacionada
<!---Todos os PRs devem ter uma issue relacionada. Dessa forma, podemos garantir que ninguém perca tempo trabalhando em algo que não precisa ser feito. -->

Closes #523 
