### PR TITLE
chore: release 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.3.0] - 2025-10-07
+
 ### Added
 
 - Utilitário `convert_code_to_uf` [#410](https://github.com/brazilian-utils/brutils-python/pull/410)
@@ -96,7 +99,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Utilitário `cnpj.display`
 - Utilitário `cnpj.validate`
 
-[Unreleased]: https://github.com/brazilian-utils/brutils-python/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/brazilian-utils/brutils-python/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/brazilian-utils/brutils-python/releases/tag/v2.3.0
 [2.2.0]: https://github.com/brazilian-utils/brutils-python/releases/tag/v2.2.0
 [2.1.1]: https://github.com/brazilian-utils/brutils-python/releases/tag/v2.1.1
 [2.1.0]: https://github.com/brazilian-utils/brutils-python/releases/tag/v2.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "brutils"
-version = "2.2.0"
+version = "2.3.0"
 description = "Utils library for specific Brazilian businesses"
 authors = ["The Brazilian Utils Organization"]
 license = "MIT"


### PR DESCRIPTION
### Added

- Utilitário `convert_code_to_uf` [#410](https://github.com/brazilian-utils/brutils-python/pull/410)
- Utilitário `is_holiday` [#446](https://github.com/brazilian-utils/brutils-python/pull/446)
- Utilitário `convert_date_to_text`[#415](https://github.com/brazilian-utils/brutils-python/pull/415)
- Utilitário `get_municipality_by_code` [412](https://github.com/brazilian-utils/brutils-python/pull/412)
- Utilitário `get_code_by_municipality_name` [#411](https://github.com/brazilian-utils/brutils-python/pull/411)
- Utilitário `format_currency` [#434](https://github.com/brazilian-utils/brutils-python/pull/434)
- Utilitário `convert_real_to_text` [#525](https://github.com/brazilian-utils/brutils-python/pull/525)
- Utilitário `convert_uf_to_name` [#554](https://github.com/brazilian-utils/brutils-python/pull/554)

### Deprecated

- **BREAKING CHANGES** Suporte ao Python 3.8 [#236](https://github.com/brazilian-utils/brutils-python/pull/561)
- **BREAKING CHANGES** Suporte ao Python 3.9 [#236](https://github.com/brazilian-utils/brutils-python/pull/561)

Closes #587
