### PR TITLE
fix: replace bare except with except Exception in tests

### DIFF
--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -16,7 +16,7 @@ class TestEmailValidation(TestCase):
         for email in valid_emails:
             try:
                 self.assertTrue(is_valid_email(email))
-            except:  # noqa: E722
+            except Exception:
                 print(f"AssertionError for email: {email}")
                 raise AssertionError
 
@@ -35,7 +35,7 @@ class TestEmailValidation(TestCase):
         for email in invalid_emails:
             try:
                 self.assertFalse(is_valid_email(email))
-            except:  # noqa: E722
+            except Exception:
                 print(f"AssertionError for email: {email}")
                 raise AssertionError
 


### PR DESCRIPTION
Fixed bare except blocks in tests/test_email.py by replacing them with 'except Exception', following Python best practices and improving error handling clarity.